### PR TITLE
Feature/restreaming

### DIFF
--- a/Jellyfin.Xtream/LiveChannel.cs
+++ b/Jellyfin.Xtream/LiveChannel.cs
@@ -192,6 +192,9 @@ namespace Jellyfin.Xtream
                             Name = channel.Name,
                             Path = uri,
                             Protocol = MediaBrowser.Model.MediaInfo.MediaProtocol.Http,
+                            SupportsDirectPlay = false,
+                            SupportsDirectStream = true,
+                            SupportsProbing = true,
                         }
                     };
                     items.Add(new ChannelItemInfo()

--- a/Jellyfin.Xtream/LiveTvService.cs
+++ b/Jellyfin.Xtream/LiveTvService.cs
@@ -17,12 +17,16 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Net.Http;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Xtream.Client;
 using Jellyfin.Xtream.Client.Models;
 using Jellyfin.Xtream.Configuration;
+using Jellyfin.Xtream.Service;
+using MediaBrowser.Controller;
+using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.LiveTv;
 using MediaBrowser.Model.Dto;
 using MediaBrowser.Model.Entities;
@@ -35,19 +39,24 @@ namespace Jellyfin.Xtream
     /// <summary>
     /// Class LiveTvService.
     /// </summary>
-    public class LiveTvService : ILiveTvService
+    public class LiveTvService : ILiveTvService, ISupportsDirectStreamProvider
     {
+        private readonly IServerApplicationHost appHost;
+        private readonly IHttpClientFactory httpClientFactory;
         private readonly ILogger<LiveTvService> logger;
         private readonly IMemoryCache memoryCache;
-        private int liveStreams;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="LiveTvService"/> class.
         /// </summary>
+        /// <param name="appHost">Instance of the <see cref="IServerApplicationHost"/> interface.</param>
+        /// <param name="httpClientFactory">Instance of the <see cref="IHttpClientFactory"/> interface.</param>
         /// <param name="logger">Instance of the <see cref="ILogger"/> interface.</param>
         /// <param name="memoryCache">Instance of the <see cref="IMemoryCache"/> interface.</param>
-        public LiveTvService(ILogger<LiveTvService> logger, IMemoryCache memoryCache)
+        public LiveTvService(IServerApplicationHost appHost, IHttpClientFactory httpClientFactory, ILogger<LiveTvService> logger, IMemoryCache memoryCache)
         {
+            this.appHost = appHost;
+            this.httpClientFactory = httpClientFactory;
             this.logger = logger;
             this.memoryCache = memoryCache;
         }
@@ -177,44 +186,7 @@ namespace Jellyfin.Xtream
         /// <inheritdoc />
         public Task<MediaSourceInfo> GetChannelStream(string channelId, string streamId, CancellationToken cancellationToken)
         {
-            Plugin? plugin = Plugin.Instance;
-            if (plugin == null)
-            {
-                throw new ArgumentException("Plugin not initialized!");
-            }
-
-            PluginConfiguration config = plugin.Configuration;
-            logger.LogInformation("Start livestream {ChannelId}", channelId);
-            liveStreams++;
-
-            string uri = $"{config.BaseUrl}/{config.Username}/{config.Password}/{channelId}";
-            var mediaSourceInfo = new MediaSourceInfo
-            {
-                Id = liveStreams.ToString(CultureInfo.InvariantCulture),
-                Path = uri,
-                Protocol = MediaProtocol.Http,
-                RequiresOpening = true,
-                MediaStreams = new List<MediaStream>
-                {
-                    new MediaStream
-                    {
-                        Type = MediaStreamType.Video,
-                        IsInterlaced = true,
-                        // Set the index to -1 because we don't know the exact index of the video stream within the container
-                        Index = -1,
-                    },
-                    new MediaStream
-                    {
-                        Type = MediaStreamType.Audio,
-                        // Set the index to -1 because we don't know the exact index of the audio stream within the container
-                        Index = -1
-                    }
-                },
-                Container = "mpegts",
-                SupportsProbing = true
-            };
-
-            return Task.FromResult(mediaSourceInfo);
+            throw new NotImplementedException();
         }
 
         /// <inheritdoc />
@@ -291,6 +263,43 @@ namespace Jellyfin.Xtream
         public Task ResetTuner(string id, CancellationToken cancellationToken)
         {
             throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public Task<ILiveStream> GetChannelStreamWithDirectStreamProvider(string channelId, string streamId, List<ILiveStream> currentLiveStreams, CancellationToken cancellationToken)
+        {
+            ILiveStream? stream = currentLiveStreams.Find(stream => stream.TunerHostId == Restream.TunerHost && stream.MediaSource.Id == channelId);
+            if (stream != null)
+            {
+                return Task.FromResult(stream);
+            }
+
+            Plugin? plugin = Plugin.Instance;
+            if (plugin == null)
+            {
+                throw new ArgumentException("Plugin not initialized!");
+            }
+
+            PluginConfiguration config = plugin.Configuration;
+
+            string uri = $"{config.BaseUrl}/{config.Username}/{config.Password}/{channelId}";
+            MediaSourceInfo mediaSourceInfo = new MediaSourceInfo()
+            {
+                EncoderProtocol = MediaProtocol.Http,
+                Id = channelId,
+                IsInfiniteStream = true,
+                IsRemote = true,
+                Path = uri,
+                Protocol = MediaProtocol.Http,
+                SupportsDirectPlay = false,
+                SupportsDirectStream = true,
+                SupportsProbing = true,
+                RequiresOpening = true,
+                RequiresClosing = true,
+            };
+
+            stream = new Restream(appHost, httpClientFactory, logger, mediaSourceInfo);
+            return Task.FromResult(stream);
         }
     }
 }

--- a/Jellyfin.Xtream/LiveTvService.cs
+++ b/Jellyfin.Xtream/LiveTvService.cs
@@ -29,7 +29,6 @@ using MediaBrowser.Controller;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.LiveTv;
 using MediaBrowser.Model.Dto;
-using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.MediaInfo;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;

--- a/Jellyfin.Xtream/Plugin.cs
+++ b/Jellyfin.Xtream/Plugin.cs
@@ -26,76 +26,78 @@ using Microsoft.Extensions.Logging;
 
 namespace Jellyfin.Xtream
 {
-/// <summary>
-/// The main plugin.
-/// </summary>
-public class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
-{
-    private readonly ILogger<Plugin> _logger;
-
     /// <summary>
-    /// Initializes a new instance of the <see cref="Plugin"/> class.
+    /// The main plugin.
     /// </summary>
-    /// <param name="applicationPaths">Instance of the <see cref="IApplicationPaths"/> interface.</param>
-    /// <param name="xmlSerializer">Instance of the <see cref="IXmlSerializer"/> interface.</param>
-    /// <param name="logger">Instance of the <see cref="ILogger"/> interface.</param>
-    public Plugin(IApplicationPaths applicationPaths, IXmlSerializer xmlSerializer, ILogger<Plugin> logger)
-        : base(applicationPaths, xmlSerializer)
+    public class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
     {
-        _logger = logger;
-        Instance = this;
-    }
+        private readonly ILogger<Plugin> _logger;
 
-    /// <inheritdoc />
-    public override string Name => "Jellyfin Xtream";
-
-    /// <inheritdoc />
-    public override Guid Id => Guid.Parse("5d774c35-8567-46d3-a950-9bb8227a0c5d");
-
-    /// <summary>
-    /// Gets the Xtream connection info with credentials.
-    /// </summary>
-    public ConnectionInfo Creds
-    {
-        get => new ConnectionInfo(this.Configuration.BaseUrl, this.Configuration.Username, this.Configuration.Password);
-    }
-
-    /// <summary>
-    /// Gets the current plugin instance.
-    /// </summary>
-    public static Plugin? Instance { get; private set; }
-
-    /// <inheritdoc />
-    public IEnumerable<PluginPageInfo> GetPages()
-    {
-        return new[]
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Plugin"/> class.
+        /// </summary>
+        /// <param name="applicationPaths">Instance of the <see cref="IApplicationPaths"/> interface.</param>
+        /// <param name="xmlSerializer">Instance of the <see cref="IXmlSerializer"/> interface.</param>
+        /// <param name="logger">Instance of the <see cref="ILogger"/> interface.</param>
+        public Plugin(IApplicationPaths applicationPaths, IXmlSerializer xmlSerializer, ILogger<Plugin> logger)
+            : base(applicationPaths, xmlSerializer)
         {
-            new PluginPageInfo
+            _logger = logger;
+            Instance = this;
+        }
+
+        /// <inheritdoc />
+        public override string Name => "Jellyfin Xtream";
+
+        /// <inheritdoc />
+        public override Guid Id => Guid.Parse("5d774c35-8567-46d3-a950-9bb8227a0c5d");
+
+        /// <summary>
+        /// Gets the Xtream connection info with credentials.
+        /// </summary>
+        public ConnectionInfo Creds
+        {
+            get => new ConnectionInfo(this.Configuration.BaseUrl, this.Configuration.Username, this.Configuration.Password);
+        }
+
+        /// <summary>
+        /// Gets the current plugin instance.
+        /// </summary>
+        public static Plugin? Instance { get; private set; }
+
+        /// <inheritdoc />
+        public IEnumerable<PluginPageInfo> GetPages()
+        {
+            CultureInfo ci = CultureInfo.InvariantCulture;
+            string? ns = GetType().Namespace;
+            return new[]
             {
-                Name = "XtreamCredentials",
-                EmbeddedResourcePath = string.Format(CultureInfo.InvariantCulture, "{0}.Configuration.Web.XtreamCredentials.html", GetType().Namespace)
-            },
-            new PluginPageInfo
-            {
-                Name = "XtreamCredentials.js",
-                EmbeddedResourcePath = string.Format(CultureInfo.InvariantCulture, "{0}.Configuration.Web.XtreamCredentials.js", GetType().Namespace)
-            },
-            new PluginPageInfo
-            {
-                Name = "XtreamLive",
-                EmbeddedResourcePath = string.Format(CultureInfo.InvariantCulture, "{0}.Configuration.Web.XtreamLive.html", GetType().Namespace)
-            },
-            new PluginPageInfo
-            {
-                Name = "XtreamLive.js",
-                EmbeddedResourcePath = string.Format(CultureInfo.InvariantCulture, "{0}.Configuration.Web.XtreamLive.js", GetType().Namespace)
-            },
-            new PluginPageInfo
-            {
-                Name = "Xtream.js",
-                EmbeddedResourcePath = string.Format(CultureInfo.InvariantCulture, "{0}.Configuration.Web.Xtream.js", GetType().Namespace)
-            }
-        };
+                new PluginPageInfo
+                {
+                    Name = "XtreamCredentials",
+                    EmbeddedResourcePath = string.Format(ci, "{0}.Configuration.Web.XtreamCredentials.html", ns)
+                },
+                new PluginPageInfo
+                {
+                    Name = "XtreamCredentials.js",
+                    EmbeddedResourcePath = string.Format(ci, "{0}.Configuration.Web.XtreamCredentials.js", ns)
+                },
+                new PluginPageInfo
+                {
+                    Name = "XtreamLive",
+                    EmbeddedResourcePath = string.Format(ci, "{0}.Configuration.Web.XtreamLive.html", ns)
+                },
+                new PluginPageInfo
+                {
+                    Name = "XtreamLive.js",
+                    EmbeddedResourcePath = string.Format(ci, "{0}.Configuration.Web.XtreamLive.js", ns)
+                },
+                new PluginPageInfo
+                {
+                    Name = "Xtream.js",
+                    EmbeddedResourcePath = string.Format(ci, "{0}.Configuration.Web.Xtream.js", ns)
+                }
+            };
+        }
     }
-}
 }

--- a/Jellyfin.Xtream/SerieChannel.cs
+++ b/Jellyfin.Xtream/SerieChannel.cs
@@ -312,6 +312,9 @@ namespace Jellyfin.Xtream
                             Name = episode.Title,
                             Path = uri,
                             Protocol = MediaBrowser.Model.MediaInfo.MediaProtocol.Http,
+                            SupportsDirectPlay = false,
+                            SupportsDirectStream = true,
+                            SupportsProbing = true,
                         }
                     };
                     items.Add(new ChannelItemInfo()

--- a/Jellyfin.Xtream/Service/Restream.cs
+++ b/Jellyfin.Xtream/Service/Restream.cs
@@ -1,0 +1,197 @@
+// Copyright (C) 2022  Kevin Jilissen
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using MediaBrowser.Common.Net;
+using MediaBrowser.Controller;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Model.Dto;
+using MediaBrowser.Model.MediaInfo;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Xtream.Service
+{
+    /// <summary>
+    /// A live stream implementation that can be restreamed.
+    /// </summary>
+    public class Restream : ILiveStream, IDisposable
+    {
+        /// <summary>
+        /// The global constant for the restream tuner host.
+        /// </summary>
+        public const string TunerHost = "Xtream-Restream";
+
+        private static readonly HttpStatusCode[] Redirects = new[]
+        {
+            HttpStatusCode.Moved,
+            HttpStatusCode.MovedPermanently,
+            HttpStatusCode.PermanentRedirect,
+            HttpStatusCode.Redirect,
+        };
+
+        private readonly IServerApplicationHost appHost;
+        private readonly WrappedBufferStream buffer;
+        private readonly IHttpClientFactory httpClientFactory;
+        private readonly ILogger logger;
+        private readonly CancellationTokenSource tokenSource;
+
+        private Task? copyTask;
+        private Stream? inputStream;
+
+        private int consumerCount;
+        private string originalStreamId;
+        private bool enableStreamSharing;
+        private MediaSourceInfo mediaSource;
+        private string uniqueId;
+        private string uri;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Restream"/> class.
+        /// </summary>
+        /// <param name="appHost">Instance of the <see cref="IServerApplicationHost"/> interface.</param>
+        /// <param name="httpClientFactory">Instance of the <see cref="IHttpClientFactory"/> interface.</param>
+        /// <param name="logger">Instance of the <see cref="ILogger"/> interface.</param>
+        /// <param name="mediaSource">The media which must be restreamed.</param>
+        public Restream(IServerApplicationHost appHost, IHttpClientFactory httpClientFactory, ILogger logger, MediaSourceInfo mediaSource)
+        {
+            this.appHost = appHost;
+            this.buffer = new WrappedBufferStream(16777216); // 16MiB
+            this.httpClientFactory = httpClientFactory;
+            this.logger = logger;
+            this.tokenSource = new CancellationTokenSource();
+
+            this.mediaSource = mediaSource;
+            this.originalStreamId = mediaSource.Id;
+            this.enableStreamSharing = true;
+            this.uniqueId = Guid.NewGuid().ToString();
+
+            this.uri = mediaSource.Path;
+            MediaSource.Path = appHost.GetApiUrlForLocalAccess() + "/LiveTv/LiveStreamFiles/" + UniqueId + "/stream.ts";
+            MediaSource.Protocol = MediaProtocol.Http;
+        }
+
+        /// <inheritdoc />
+        public int ConsumerCount { get => consumerCount; set => consumerCount = value; }
+
+        /// <inheritdoc />
+        public string OriginalStreamId { get => originalStreamId; set => originalStreamId = value; }
+
+        /// <inheritdoc />
+        public string TunerHostId { get => TunerHost; }
+
+        /// <inheritdoc />
+        public bool EnableStreamSharing { get => enableStreamSharing; }
+
+        /// <inheritdoc />
+        public MediaSourceInfo MediaSource { get => mediaSource; set => mediaSource = value; }
+
+        /// <inheritdoc />
+        public string UniqueId { get => uniqueId; }
+
+        /// <inheritdoc />
+        public async Task Open(CancellationToken openCancellationToken)
+        {
+            if (inputStream != null)
+            {
+                // Channel is already opened.
+                return;
+            }
+
+            string channelId = mediaSource.Id;
+            this.logger.LogInformation("Starting restream for channel {ChannelId}.", channelId);
+
+            // Response stream is disposed manually.
+            HttpResponseMessage response = await this.httpClientFactory.CreateClient(NamedClient.Default)
+                .GetAsync(uri, HttpCompletionOption.ResponseHeadersRead, CancellationToken.None)
+                .ConfigureAwait(true);
+            this.logger.LogDebug("Stream for channel {ChannelId} using url {Url}", channelId, uri);
+
+            // Handle a manual redirect in the case of a HTTPS to HTTP downgrade.
+            if (Redirects.Contains(response.StatusCode))
+            {
+                this.logger.LogDebug("Stream for channel {ChannelId} redirected to url {Url}", channelId, response.Headers.Location);
+                response = await this.httpClientFactory.CreateClient(NamedClient.Default)
+                    .GetAsync(response.Headers.Location, HttpCompletionOption.ResponseHeadersRead, CancellationToken.None)
+                    .ConfigureAwait(true);
+            }
+
+            inputStream = await response.Content.ReadAsStreamAsync(CancellationToken.None).ConfigureAwait(false);
+            copyTask = Task.Run(() => inputStream.CopyTo(buffer), tokenSource.Token);
+        }
+
+        /// <inheritdoc />
+        public async Task Close()
+        {
+            if (inputStream == null || copyTask == null)
+            {
+                throw new ArgumentNullException("inputStream");
+            }
+
+            tokenSource.Cancel();
+            inputStream.Close();
+            inputStream = null;
+            await copyTask.ConfigureAwait(false);
+        }
+
+        /// <inheritdoc />
+        public Stream GetStream()
+        {
+            if (inputStream == null)
+            {
+                this.logger.LogInformation("Restream for channel {ChannelId} was not opened.", mediaSource.Id);
+                Task open = Open(CancellationToken.None);
+            }
+
+            consumerCount++;
+            this.logger.LogInformation("Opening restream {Count} for channel {ChannelId}.", consumerCount, mediaSource.Id);
+            return new WrappedBufferReadStream(this.buffer);
+        }
+
+        /// <summary>
+        /// Disposes the fields.
+        /// </summary>
+        /// <param name="disposing">Whether or not to dispose.</param>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                this.inputStream?.Dispose();
+                this.buffer.Dispose();
+                this.tokenSource.Dispose();
+            }
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            // Implement IDisposable.
+            // Do not make this method virtual.
+            // A derived class should not be able to override this method.
+            Dispose(true);
+            // This object will be cleaned up by the Dispose method.
+            // Therefore, you should call GC.SuppressFinalize to
+            // take this object off the finalization queue
+            // and prevent finalization code for this object
+            // from executing a second time.
+            GC.SuppressFinalize(this);
+        }
+    }
+}

--- a/Jellyfin.Xtream/Service/Restream.cs
+++ b/Jellyfin.Xtream/Service/Restream.cs
@@ -52,16 +52,16 @@ namespace Jellyfin.Xtream.Service
         private readonly IHttpClientFactory httpClientFactory;
         private readonly ILogger logger;
         private readonly CancellationTokenSource tokenSource;
+        private readonly bool enableStreamSharing;
+        private readonly string uniqueId;
+        private readonly string uri;
 
         private Task? copyTask;
         private Stream? inputStream;
 
         private int consumerCount;
         private string originalStreamId;
-        private bool enableStreamSharing;
         private MediaSourceInfo mediaSource;
-        private string uniqueId;
-        private string uri;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Restream"/> class.

--- a/Jellyfin.Xtream/Service/WrappedBufferReadStream.cs
+++ b/Jellyfin.Xtream/Service/WrappedBufferReadStream.cs
@@ -1,0 +1,151 @@
+// Copyright (C) 2022  Kevin Jilissen
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Xtream.Client.Models;
+using Jellyfin.Xtream.Configuration;
+using MediaBrowser.Common.Net;
+using MediaBrowser.Model.Dto;
+using MediaBrowser.Model.IO;
+using MediaBrowser.Model.MediaInfo;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Xtream.Service
+{
+    /// <summary>
+    /// Stream which writes to a self-overwriting internal buffer.
+    /// </summary>
+    public class WrappedBufferReadStream : Stream
+    {
+        private readonly WrappedBufferStream buffer;
+
+        private long position;
+        private long readHead;
+        private long totalBytesRead;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WrappedBufferReadStream"/> class.
+        /// </summary>
+        /// <param name="buffer">The source buffer to read from.</param>
+        public WrappedBufferReadStream(WrappedBufferStream buffer)
+        {
+            this.buffer = buffer;
+            this.readHead = buffer.TotalBytesWritten;
+            this.totalBytesRead = 0;
+            this.Position = buffer.Position;
+        }
+
+        /// <summary>
+        /// Gets the virtual position in the source buffer.
+        /// </summary>
+        public long ReadHead { get => readHead; }
+
+        /// <summary>
+        /// Gets the number of bytes that have been written to this stream.
+        /// </summary>
+        public long TotalBytesRead { get => totalBytesRead; }
+
+        /// <inheritdoc />
+        public override long Position { get => position; set => position = value; }
+
+        /// <inheritdoc />
+        public override bool CanRead => true;
+
+        /// <inheritdoc />
+        public override bool CanWrite => false;
+
+        /// <inheritdoc />
+        public override bool CanSeek => false;
+
+#pragma warning disable CA1065
+        /// <inheritdoc />
+        public override long Length { get => throw new NotImplementedException(); }
+#pragma warning restore CA1065
+
+        /// <inheritdoc />
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            long gap = this.buffer.TotalBytesWritten - readHead;
+            if (gap > this.buffer.BufferSize)
+            {
+                // TODO: design good handling method.
+                // Options:
+                // - throw exception
+                // - skip to buffer.Position+1 to only read 'up-to-date' bytes.
+                throw new IOException("Reader cannot keep up");
+            }
+
+            // The bytes that still need to be copied.
+            long remaining = Math.Min(count, this.buffer.TotalBytesWritten - readHead);
+            long remainingOffset = offset;
+
+            long read = 0;
+
+            // Copy inside a loop to simplify wrapping logic.
+            while (remaining > 0)
+            {
+                // The amount of bytes that we can directly write from the current position without wrapping.
+                long readable = Math.Min(remaining, this.buffer.BufferSize - Position);
+
+                // Copy the data.
+                Array.Copy(this.buffer.Buffer, Position, buffer, remainingOffset, readable);
+                remaining -= readable;
+                remainingOffset += readable;
+
+                read += readable;
+                Position += readable;
+                readHead += readable;
+                totalBytesRead += readable;
+
+                // We might have to loop the position.
+                Position %= this.buffer.BufferSize;
+            }
+
+            return (int)read;
+        }
+
+        /// <inheritdoc />
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public override void SetLength(long value)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public override void Flush()
+        {
+            // Do nothing
+        }
+    }
+}

--- a/Jellyfin.Xtream/Service/WrappedBufferStream.cs
+++ b/Jellyfin.Xtream/Service/WrappedBufferStream.cs
@@ -1,0 +1,138 @@
+// Copyright (C) 2022  Kevin Jilissen
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Xtream.Client.Models;
+using Jellyfin.Xtream.Configuration;
+using MediaBrowser.Common.Net;
+using MediaBrowser.Model.Dto;
+using MediaBrowser.Model.IO;
+using MediaBrowser.Model.MediaInfo;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Xtream.Service
+{
+    /// <summary>
+    /// Stream which writes to a self-overwriting internal buffer.
+    /// </summary>
+    public class WrappedBufferStream : Stream
+    {
+        private readonly byte[] buffer;
+
+        private long position;
+        private long totalBytesWritten;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WrappedBufferStream"/> class.
+        /// </summary>
+        /// <param name="bufferSize">Size in bytes of the internal buffer.</param>
+        public WrappedBufferStream(int bufferSize)
+        {
+            this.buffer = new byte[bufferSize];
+            this.totalBytesWritten = 0;
+        }
+
+        /// <summary>
+        /// Gets the maximal size in bytes of read/write chunks.
+        /// </summary>
+        public int BufferSize { get => buffer.Length; }
+
+#pragma warning disable CA1819
+        /// <summary>
+        /// Gets the internal buffer.
+        /// </summary>
+        public byte[] Buffer { get => buffer; }
+#pragma warning restore CA1819
+
+        /// <summary>
+        /// Gets the number of bytes that have been written to this stream.
+        /// </summary>
+        public long TotalBytesWritten { get => totalBytesWritten; }
+
+        /// <inheritdoc />
+        public override long Position { get => position; set => position = value; }
+
+        /// <inheritdoc />
+        public override bool CanRead => false;
+
+        /// <inheritdoc />
+        public override bool CanWrite => true;
+
+        /// <inheritdoc />
+        public override bool CanSeek => false;
+
+#pragma warning disable CA1065
+        /// <inheritdoc />
+        public override long Length { get => throw new NotImplementedException(); }
+#pragma warning restore CA1065
+
+        /// <inheritdoc />
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            // The bytes that still need to be copied.
+            long remaining = count;
+            long remainingOffset = offset;
+
+            // Copy inside a loop to simplify wrapping logic.
+            while (remaining > 0)
+            {
+                // The amount of bytes that we can directly write from the current position without wrapping.
+                long writable = Math.Min(remaining, BufferSize - Position);
+
+                // Copy the data.
+                Array.Copy(buffer, remainingOffset, this.buffer, Position, writable);
+                remaining -= writable;
+                remainingOffset += writable;
+                Position += writable;
+                totalBytesWritten += writable;
+
+                // We might have to wrap the position.
+                Position %= BufferSize;
+            }
+        }
+
+        /// <inheritdoc />
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public override void SetLength(long value)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public override void Flush()
+        {
+            // Do nothing
+        }
+    }
+}

--- a/Jellyfin.Xtream/Service/WrappedBufferStream.cs
+++ b/Jellyfin.Xtream/Service/WrappedBufferStream.cs
@@ -14,21 +14,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Net;
-using System.Net.Http;
-using System.Net.Sockets;
-using System.Threading;
-using System.Threading.Tasks;
-using Jellyfin.Xtream.Client.Models;
-using Jellyfin.Xtream.Configuration;
-using MediaBrowser.Common.Net;
-using MediaBrowser.Model.Dto;
-using MediaBrowser.Model.IO;
-using MediaBrowser.Model.MediaInfo;
-using Microsoft.Extensions.Logging;
 
 namespace Jellyfin.Xtream.Service
 {
@@ -37,7 +23,7 @@ namespace Jellyfin.Xtream.Service
     /// </summary>
     public class WrappedBufferStream : Stream
     {
-        private readonly byte[] buffer;
+        private readonly byte[] sourceBuffer;
 
         private long position;
         private long totalBytesWritten;
@@ -48,20 +34,20 @@ namespace Jellyfin.Xtream.Service
         /// <param name="bufferSize">Size in bytes of the internal buffer.</param>
         public WrappedBufferStream(int bufferSize)
         {
-            this.buffer = new byte[bufferSize];
+            this.sourceBuffer = new byte[bufferSize];
             this.totalBytesWritten = 0;
         }
 
         /// <summary>
         /// Gets the maximal size in bytes of read/write chunks.
         /// </summary>
-        public int BufferSize { get => buffer.Length; }
+        public int BufferSize { get => sourceBuffer.Length; }
 
 #pragma warning disable CA1819
         /// <summary>
         /// Gets the internal buffer.
         /// </summary>
-        public byte[] Buffer { get => buffer; }
+        public byte[] Buffer { get => sourceBuffer; }
 #pragma warning restore CA1819
 
         /// <summary>
@@ -106,7 +92,7 @@ namespace Jellyfin.Xtream.Service
                 long writable = Math.Min(remaining, BufferSize - Position);
 
                 // Copy the data.
-                Array.Copy(buffer, remainingOffset, this.buffer, Position, writable);
+                Array.Copy(buffer, remainingOffset, sourceBuffer, Position, writable);
                 remaining -= writable;
                 remainingOffset += writable;
                 Position += writable;

--- a/Jellyfin.Xtream/VodChannel.cs
+++ b/Jellyfin.Xtream/VodChannel.cs
@@ -194,6 +194,9 @@ namespace Jellyfin.Xtream
                             Name = channel.Name,
                             Path = uri,
                             Protocol = MediaBrowser.Model.MediaInfo.MediaProtocol.Http,
+                            SupportsDirectPlay = false,
+                            SupportsDirectStream = true,
+                            SupportsProbing = true,
                         }
                     };
                     items.Add(new ChannelItemInfo()


### PR DESCRIPTION
Add stream sharing support using the `Restream` class.

As discussed on [Matrix](https://matrix.to/#/!YOoxJKhsHoXZiIHyBG:matrix.org/$_1Kg-ItNzX51As5ERcRNjrMfWYmA6z15B9YeQowKWxc), the functionality is not available directly by Jellyfin. Therefore, a custom wrapped stream class has been implemented.