### PR TITLE
Feature/tagging

### DIFF
--- a/Jellyfin.Xtream/LiveChannel.cs
+++ b/Jellyfin.Xtream/LiveChannel.cs
@@ -19,7 +19,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Xtream.Client;
 using Jellyfin.Xtream.Client.Models;
-using Jellyfin.Xtream.Configuration;
 using Jellyfin.Xtream.Service;
 using MediaBrowser.Controller.Channels;
 using MediaBrowser.Controller.Providers;

--- a/Jellyfin.Xtream/LiveTvService.cs
+++ b/Jellyfin.Xtream/LiveTvService.cs
@@ -19,7 +19,6 @@ using System.Globalization;
 using System.Linq;
 using System.Net.Http;
 using System.Runtime.CompilerServices;
-using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Xtream.Client;
@@ -30,7 +29,6 @@ using MediaBrowser.Controller;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.LiveTv;
 using MediaBrowser.Model.Dto;
-using MediaBrowser.Model.MediaInfo;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 

--- a/Jellyfin.Xtream/Plugin.cs
+++ b/Jellyfin.Xtream/Plugin.cs
@@ -18,6 +18,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using Jellyfin.Xtream.Client;
 using Jellyfin.Xtream.Configuration;
+using Jellyfin.Xtream.Service;
 using MediaBrowser.Common.Configuration;
 using MediaBrowser.Common.Plugins;
 using MediaBrowser.Model.Plugins;
@@ -44,6 +45,7 @@ namespace Jellyfin.Xtream
         {
             _logger = logger;
             Instance = this;
+            StreamService = new StreamService(logger, this);
         }
 
         /// <inheritdoc />
@@ -64,6 +66,11 @@ namespace Jellyfin.Xtream
         /// Gets the current plugin instance.
         /// </summary>
         public static Plugin? Instance { get; private set; }
+
+        /// <summary>
+        /// Gets the stream service instance.
+        /// </summary>
+        public StreamService StreamService { get; init; }
 
         /// <inheritdoc />
         public IEnumerable<PluginPageInfo> GetPages()

--- a/Jellyfin.Xtream/SerieChannel.cs
+++ b/Jellyfin.Xtream/SerieChannel.cs
@@ -207,7 +207,7 @@ namespace Jellyfin.Xtream
                         {
                             Name = name.Trim()
                         }).ToList(),
-                        FolderType = ChannelFolderType.Series,
+                        // FolderType = ChannelFolderType.Series,
                     });
                 }
 
@@ -254,7 +254,7 @@ namespace Jellyfin.Xtream
                             Type = ChannelItemType.Folder,
                             ImageUrl = season.Cover,
                             DateCreated = season.AirDate,
-                            FolderType = ChannelFolderType.Season,
+                            // FolderType = ChannelFolderType.Season,
                         });
                     }
                     else
@@ -265,7 +265,7 @@ namespace Jellyfin.Xtream
                             Name = $"Season {seasonId}",
                             Type = ChannelItemType.Folder,
                             ImageUrl = series.Info.Cover,
-                            FolderType = ChannelFolderType.Season,
+                            // FolderType = ChannelFolderType.Season,
                         });
                     }
                 }

--- a/Jellyfin.Xtream/SerieChannel.cs
+++ b/Jellyfin.Xtream/SerieChannel.cs
@@ -22,6 +22,7 @@ using System.Threading.Tasks;
 using Jellyfin.Xtream.Client;
 using Jellyfin.Xtream.Client.Models;
 using Jellyfin.Xtream.Configuration;
+using Jellyfin.Xtream.Service;
 using MediaBrowser.Controller.Channels;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Providers;
@@ -150,10 +151,12 @@ namespace Jellyfin.Xtream
 
                 foreach (Category category in categories)
                 {
+                    ParsedName parsedName = plugin.StreamService.ParseName(category.CategoryName);
                     items.Add(new ChannelItemInfo()
                     {
                         Id = $"cat-{category.CategoryId}",
                         Name = category.CategoryName,
+                        Tags = new List<string>(parsedName.Tags),
                         Type = ChannelItemType.Folder,
                     });
                 }
@@ -189,10 +192,12 @@ namespace Jellyfin.Xtream
 
                 foreach (Series serie in series)
                 {
+                    ParsedName parsedName = plugin.StreamService.ParseName(serie.Name);
                     items.Add(new ChannelItemInfo()
                     {
                         Id = $"ser-{serie.SeriesId}",
-                        Name = serie.Name,
+                        Name = parsedName.Title,
+                        Tags = new List<string>(parsedName.Tags),
                         Type = ChannelItemType.Folder,
                         ImageUrl = serie.Cover,
                         DateModified = serie.LastModified,
@@ -240,10 +245,12 @@ namespace Jellyfin.Xtream
                     Season? season = series.Seasons.FirstOrDefault(s => s.SeasonId == seasonId);
                     if (season != null)
                     {
+                        ParsedName parsedName = plugin.StreamService.ParseName(season.Name);
                         items.Add(new ChannelItemInfo()
                         {
                             Id = $"{seriesId}-{seasonId}",
-                            Name = season.Name,
+                            Name = parsedName.Title,
+                            Tags = new List<string>(parsedName.Tags),
                             Type = ChannelItemType.Folder,
                             ImageUrl = season.Cover,
                             DateCreated = season.AirDate,
@@ -294,39 +301,24 @@ namespace Jellyfin.Xtream
 
                 foreach (Episode episode in channel.Episodes[season])
                 {
-                    PluginConfiguration config = plugin.Configuration;
-                    string uri = $"{config.BaseUrl}/series/{config.Username}/{config.Password}/{episode.EpisodeId}";
-                    if (!string.IsNullOrEmpty(episode.ContainerExtension))
-                    {
-                        uri += $".{episode.ContainerExtension}";
-                    }
-
+                    string id = episode.EpisodeId.ToString(System.Globalization.CultureInfo.InvariantCulture);
+                    ParsedName parsedName = plugin.StreamService.ParseName(episode.Title);
                     List<MediaSourceInfo> sources = new List<MediaSourceInfo>()
                     {
-                        new MediaSourceInfo()
-                        {
-                            EncoderProtocol = MediaBrowser.Model.MediaInfo.MediaProtocol.Http,
-                            Id = "xtream-series-" + episode.EpisodeId,
-                            IsInfiniteStream = false,
-                            IsRemote = true,
-                            Name = episode.Title,
-                            Path = uri,
-                            Protocol = MediaBrowser.Model.MediaInfo.MediaProtocol.Http,
-                            SupportsDirectPlay = false,
-                            SupportsDirectStream = true,
-                            SupportsProbing = true,
-                        }
+                        plugin.StreamService.GetMediaSourceInfo(StreamType.Series, id, episode.ContainerExtension)
                     };
+
                     items.Add(new ChannelItemInfo()
                     {
                         ContentType = ChannelMediaContentType.Episode,
                         DateCreated = DateTimeOffset.FromUnixTimeSeconds(episode.Added).DateTime,
-                        Id = episode.EpisodeId.ToString(System.Globalization.CultureInfo.InvariantCulture),
+                        Id = id,
                         ImageUrl = episode.Info.MovieImage,
                         IsLiveStream = false,
                         MediaSources = sources,
                         MediaType = ChannelMediaType.Video,
-                        Name = episode.Title,
+                        Name = parsedName.Title,
+                        Tags = new List<string>(parsedName.Tags),
                         Type = ChannelItemType.Media,
                     });
                 }

--- a/Jellyfin.Xtream/SerieChannel.cs
+++ b/Jellyfin.Xtream/SerieChannel.cs
@@ -21,7 +21,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Xtream.Client;
 using Jellyfin.Xtream.Client.Models;
-using Jellyfin.Xtream.Configuration;
 using Jellyfin.Xtream.Service;
 using MediaBrowser.Controller.Channels;
 using MediaBrowser.Controller.Entities;

--- a/Jellyfin.Xtream/Service/ParsedName.cs
+++ b/Jellyfin.Xtream/Service/ParsedName.cs
@@ -1,0 +1,46 @@
+// Copyright (C) 2022  Kevin Jilissen
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#pragma warning disable CA1815
+#pragma warning disable CA1819
+namespace Jellyfin.Xtream.Service
+{
+    /// <summary>
+    /// A struct which holds information of parsed stream names.
+    /// </summary>
+    public struct ParsedName
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ParsedName"/> struct.
+        /// </summary>
+        /// <param name="title">The parsed title.</param>
+        /// <param name="tags">The parsed tags.</param>
+        public ParsedName(string title, string[] tags)
+        {
+            Title = title;
+            Tags = tags;
+        }
+
+        /// <summary>
+        /// Gets the parsed title.
+        /// </summary>
+        public string Title { get; init; }
+
+        /// <summary>
+        /// Gets the parsed tags.
+        /// </summary>
+        public string[] Tags { get; init; }
+    }
+}

--- a/Jellyfin.Xtream/Service/StreamService.cs
+++ b/Jellyfin.Xtream/Service/StreamService.cs
@@ -1,0 +1,132 @@
+// Copyright (C) 2022  Kevin Jilissen
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Xtream;
+using Jellyfin.Xtream.Configuration;
+using MediaBrowser.Model.Dto;
+using MediaBrowser.Model.MediaInfo;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Xtream.Service
+{
+    /// <summary>
+    /// A service for dealing with stream information.
+    /// </summary>
+    public class StreamService
+    {
+        private static readonly Regex TagRegex = new Regex(@"\[([^\]]+)\]|\|([^\|]+)\|");
+
+        private readonly ILogger logger;
+        private readonly Plugin plugin;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StreamService"/> class.
+        /// </summary>
+        /// <param name="logger">Instance of the <see cref="ILogger"/> interface.</param>
+        /// <param name="plugin">Instance of the <see cref="Plugin"/> class.</param>
+        public StreamService(ILogger logger, Plugin plugin)
+        {
+            this.logger = logger;
+            this.plugin = plugin;
+        }
+
+        /// <summary>
+        /// Parses tags in the name of a stream entry.
+        /// The name commonly contains tags of the forms:
+        /// <list>
+        /// <item>[TAG]</item>
+        /// <item>|TAG|</item>
+        /// </list>
+        /// These tags are parsed and returned as separate strings.
+        /// The returned title is cleaned from tags and trimmed.
+        /// </summary>
+        /// <param name="name">The name which should be parsed.</param>
+        /// <returns>A <see cref="ParsedName"/> struct containing the cleaned title and parsed tags.</returns>
+        public ParsedName ParseName(string name)
+        {
+            List<string> tags = new List<string>();
+            string title = TagRegex.Replace(
+                name,
+                (match) =>
+                {
+                    for (int i = 1; i < match.Groups.Count; ++i)
+                    {
+                        Group g = match.Groups[i];
+                        if (g.Success)
+                        {
+                            tags.Add(g.Value);
+                        }
+                    }
+
+                    return string.Empty;
+                });
+
+            return new ParsedName
+            {
+                Title = title.Trim(),
+                Tags = tags.ToArray(),
+            };
+        }
+
+        /// <summary>
+        /// Gets the media source information for the given Xtream stream.
+        /// </summary>
+        /// <param name="type">The stream media type.</param>
+        /// <param name="id">The unique identifier of the stream.</param>
+        /// <param name="extension">The container extension of the stream.</param>
+        /// <returns>The media source info as <see cref="MediaSourceInfo"/> class.</returns>
+        public MediaSourceInfo GetMediaSourceInfo(StreamType type, string id, string? extension)
+        {
+            string prefix = string.Empty;
+            switch (type)
+            {
+                case StreamType.Series:
+                    prefix = "/series";
+                    break;
+                case StreamType.Vod:
+                    prefix = "/movie";
+                    break;
+            }
+
+            PluginConfiguration config = plugin.Configuration;
+            string uri = $"{config.BaseUrl}{prefix}/{config.Username}/{config.Password}/{id}";
+            if (!string.IsNullOrEmpty(extension))
+            {
+                uri += $".{extension}";
+            }
+
+            bool isLive = type == StreamType.Live;
+            return new MediaSourceInfo()
+            {
+                EncoderProtocol = MediaProtocol.Http,
+                Id = id,
+                IsInfiniteStream = isLive,
+                IsRemote = true,
+                Path = uri,
+                Protocol = MediaProtocol.Http,
+                SupportsDirectPlay = false,
+                SupportsDirectStream = true,
+                SupportsProbing = true,
+                RequiresOpening = true,
+                RequiresClosing = true,
+            };
+        }
+    }
+}

--- a/Jellyfin.Xtream/Service/StreamService.cs
+++ b/Jellyfin.Xtream/Service/StreamService.cs
@@ -121,11 +121,11 @@ namespace Jellyfin.Xtream.Service
                 IsRemote = true,
                 Path = uri,
                 Protocol = MediaProtocol.Http,
+                RequiresClosing = isLive,
+                RequiresOpening = isLive,
                 SupportsDirectPlay = false,
                 SupportsDirectStream = true,
                 SupportsProbing = true,
-                RequiresOpening = true,
-                RequiresClosing = true,
             };
         }
     }

--- a/Jellyfin.Xtream/Service/StreamService.cs
+++ b/Jellyfin.Xtream/Service/StreamService.cs
@@ -13,12 +13,8 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-using System;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
-using System.Threading;
-using System.Threading.Tasks;
-using Jellyfin.Xtream;
 using Jellyfin.Xtream.Configuration;
 using MediaBrowser.Model.Dto;
 using MediaBrowser.Model.MediaInfo;

--- a/Jellyfin.Xtream/Service/StreamType.cs
+++ b/Jellyfin.Xtream/Service/StreamType.cs
@@ -1,0 +1,38 @@
+// Copyright (C) 2022  Kevin Jilissen
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+namespace Jellyfin.Xtream.Service
+{
+    /// <summary>
+    /// An enum describing the Xtream stream types.
+    /// </summary>
+    public enum StreamType
+    {
+        /// <summary>
+        /// Live IPTV.
+        /// </summary>
+        Live,
+
+        /// <summary>
+        /// On-demand series grouped in seasons and episodes.
+        /// </summary>
+        Series,
+
+        /// <summary>
+        /// Video on-demand.
+        /// </summary>
+        Vod,
+    }
+}

--- a/Jellyfin.Xtream/VodChannel.cs
+++ b/Jellyfin.Xtream/VodChannel.cs
@@ -131,7 +131,6 @@ namespace Jellyfin.Xtream
             using (XtreamClient client = new XtreamClient())
             {
                 List<Category> categories = await client.GetVodCategoryAsync(plugin.Creds, cancellationToken).ConfigureAwait(false);
-                this.logger.LogInformation("{Array}", JsonConvert.SerializeObject(categories));
                 List<ChannelItemInfo> items = new List<ChannelItemInfo>();
 
                 foreach (Category category in categories)

--- a/Jellyfin.Xtream/VodChannel.cs
+++ b/Jellyfin.Xtream/VodChannel.cs
@@ -20,6 +20,7 @@ using System.Threading.Tasks;
 using Jellyfin.Xtream.Client;
 using Jellyfin.Xtream.Client.Models;
 using Jellyfin.Xtream.Configuration;
+using Jellyfin.Xtream.Service;
 using MediaBrowser.Controller.Channels;
 using MediaBrowser.Controller.Providers;
 using MediaBrowser.Model.Channels;
@@ -135,10 +136,12 @@ namespace Jellyfin.Xtream
 
                 foreach (Category category in categories)
                 {
+                    ParsedName parsedName = plugin.StreamService.ParseName(category.CategoryName);
                     items.Add(new ChannelItemInfo()
                     {
                         Id = category.CategoryId.ToString(System.Globalization.CultureInfo.InvariantCulture),
                         Name = category.CategoryName,
+                        Tags = new List<string>(parsedName.Tags),
                         Type = ChannelItemType.Folder,
                     });
                 }
@@ -169,47 +172,31 @@ namespace Jellyfin.Xtream
 
             using (XtreamClient client = new XtreamClient())
             {
-                var channels = await client.GetVodStreamsByCategoryAsync(plugin.Creds, categoryId, cancellationToken).ConfigureAwait(false);
+                IEnumerable<StreamInfo> vods = await client.GetVodStreamsByCategoryAsync(plugin.Creds, categoryId, cancellationToken).ConfigureAwait(false);
                 List<ChannelItemInfo> items = new List<ChannelItemInfo>();
 
-                foreach (var channel in channels)
+                foreach (StreamInfo vod in vods)
                 {
-                    long added = long.Parse(channel.Added, System.Globalization.CultureInfo.InvariantCulture);
-
-                    PluginConfiguration config = plugin.Configuration;
-                    string uri = $"{config.BaseUrl}/movie/{config.Username}/{config.Password}/{channel.StreamId}";
-                    if (!string.IsNullOrEmpty(channel.ContainerExtension))
-                    {
-                        uri += $".{channel.ContainerExtension}";
-                    }
-
+                    string id = vod.StreamId.ToString(System.Globalization.CultureInfo.InvariantCulture);
+                    long added = long.Parse(vod.Added, System.Globalization.CultureInfo.InvariantCulture);
+                    ParsedName parsedName = plugin.StreamService.ParseName(vod.Name);
                     List<MediaSourceInfo> sources = new List<MediaSourceInfo>()
                     {
-                        new MediaSourceInfo()
-                        {
-                            EncoderProtocol = MediaBrowser.Model.MediaInfo.MediaProtocol.Http,
-                            Id = "xtream-vod-" + channel.StreamId,
-                            IsInfiniteStream = false,
-                            IsRemote = true,
-                            Name = channel.Name,
-                            Path = uri,
-                            Protocol = MediaBrowser.Model.MediaInfo.MediaProtocol.Http,
-                            SupportsDirectPlay = false,
-                            SupportsDirectStream = true,
-                            SupportsProbing = true,
-                        }
+                        plugin.StreamService.GetMediaSourceInfo(StreamType.Vod, id, vod.ContainerExtension)
                     };
+
                     items.Add(new ChannelItemInfo()
                     {
                         ContentType = ChannelMediaContentType.Movie,
                         DateCreated = DateTimeOffset.FromUnixTimeSeconds(added).DateTime,
                         FolderType = ChannelFolderType.Container,
-                        Id = channel.StreamId.ToString(System.Globalization.CultureInfo.InvariantCulture),
-                        ImageUrl = channel.StreamIcon,
+                        Id = id,
+                        ImageUrl = vod.StreamIcon,
                         IsLiveStream = false,
                         MediaSources = sources,
                         MediaType = ChannelMediaType.Video,
-                        Name = channel.Name,
+                        Name = parsedName.Title,
+                        Tags = new List<string>(parsedName.Tags),
                         Type = ChannelItemType.Media,
                     });
                 }

--- a/Jellyfin.Xtream/VodChannel.cs
+++ b/Jellyfin.Xtream/VodChannel.cs
@@ -19,7 +19,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Xtream.Client;
 using Jellyfin.Xtream.Client.Models;
-using Jellyfin.Xtream.Configuration;
 using Jellyfin.Xtream.Service;
 using MediaBrowser.Controller.Channels;
 using MediaBrowser.Controller.Providers;
@@ -28,7 +27,6 @@ using MediaBrowser.Model.Dto;
 using MediaBrowser.Model.Entities;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
-using Newtonsoft.Json;
 
 namespace Jellyfin.Xtream
 {


### PR DESCRIPTION
Related to #10 

As Jellyfin has no support for filtering by tag for Live TV or Channels, the use is still limited.

Categories still show the tags in the title, as there is no other way to distinguish items with identical names but different tags in the Jellyfin client. Once tags can be displayed nicely for folders this can also be implemented by changing `Name = category.CategoryName,` to `Name = parsedName.Title,` in the channels.