### PR TITLE
Fix opening streams in Xtream Live

### DIFF
--- a/Jellyfin.Xtream/LiveTvService.cs
+++ b/Jellyfin.Xtream/LiveTvService.cs
@@ -280,7 +280,7 @@ namespace Jellyfin.Xtream
                 throw new ArgumentException("Plugin not initialized!");
             }
 
-            MediaSourceInfo mediaSourceInfo = plugin.StreamService.GetMediaSourceInfo(StreamType.Live, channelId, null);
+            MediaSourceInfo mediaSourceInfo = plugin.StreamService.GetMediaSourceInfo(StreamType.Live, channelId, null, true);
             stream = new Restream(appHost, httpClientFactory, logger, mediaSourceInfo);
             return Task.FromResult(stream);
         }

--- a/Jellyfin.Xtream/Service/StreamService.cs
+++ b/Jellyfin.Xtream/Service/StreamService.cs
@@ -87,8 +87,9 @@ namespace Jellyfin.Xtream.Service
         /// <param name="type">The stream media type.</param>
         /// <param name="id">The unique identifier of the stream.</param>
         /// <param name="extension">The container extension of the stream.</param>
+        /// <param name="restream">Boolean indicating whether or not restreaming is used.</param>
         /// <returns>The media source info as <see cref="MediaSourceInfo"/> class.</returns>
-        public MediaSourceInfo GetMediaSourceInfo(StreamType type, string id, string? extension)
+        public MediaSourceInfo GetMediaSourceInfo(StreamType type, string id, string? extension, bool restream = false)
         {
             string prefix = string.Empty;
             switch (type)
@@ -118,8 +119,8 @@ namespace Jellyfin.Xtream.Service
                 Name = "default",
                 Path = uri,
                 Protocol = MediaProtocol.Http,
-                RequiresClosing = isLive,
-                RequiresOpening = isLive,
+                RequiresClosing = restream,
+                RequiresOpening = restream,
                 SupportsDirectPlay = false,
                 SupportsDirectStream = true,
                 SupportsProbing = true,


### PR DESCRIPTION
Fix opening streams in Xtream Live, as they do not need opening and closing but are StreamType.Live.

Closes #18 