### PR TITLE
Fix caching issues on credentials change

### DIFF
--- a/Jellyfin.Xtream/LiveChannel.cs
+++ b/Jellyfin.Xtream/LiveChannel.cs
@@ -56,7 +56,7 @@ namespace Jellyfin.Xtream
         public string? Description => "Live IPTV streamed from the Xtream-compatible server.";
 
         /// <inheritdoc />
-        public string DataVersion => string.Empty;
+        public string DataVersion => Plugin.Instance.Creds.ToString();
 
         /// <inheritdoc />
         public string HomePageUrl => string.Empty;

--- a/Jellyfin.Xtream/LiveChannel.cs
+++ b/Jellyfin.Xtream/LiveChannel.cs
@@ -25,7 +25,6 @@ using MediaBrowser.Controller.Providers;
 using MediaBrowser.Model.Channels;
 using MediaBrowser.Model.Dto;
 using MediaBrowser.Model.Entities;
-using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 
 namespace Jellyfin.Xtream
@@ -36,17 +35,14 @@ namespace Jellyfin.Xtream
     public class LiveChannel : IChannel
     {
         private readonly ILogger<LiveChannel> logger;
-        private readonly IMemoryCache memoryCache;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="LiveChannel"/> class.
         /// </summary>
         /// <param name="logger">Instance of the <see cref="ILogger"/> interface.</param>
-        /// <param name="memoryCache">Instance of the <see cref="IMemoryCache"/> interface.</param>
-        public LiveChannel(ILogger<LiveChannel> logger, IMemoryCache memoryCache)
+        public LiveChannel(ILogger<LiveChannel> logger)
         {
             this.logger = logger;
-            this.memoryCache = memoryCache;
         }
 
         /// <inheritdoc />
@@ -113,12 +109,6 @@ namespace Jellyfin.Xtream
 
         private async Task<ChannelItemResult> GetCategories(CancellationToken cancellationToken)
         {
-            string key = "xtream-live-categories";
-            if (memoryCache.TryGetValue(key, out ChannelItemResult o))
-            {
-                return o;
-            }
-
             Plugin plugin = Plugin.Instance;
             using (XtreamClient client = new XtreamClient())
             {
@@ -142,19 +132,12 @@ namespace Jellyfin.Xtream
                     Items = items,
                     TotalRecordCount = items.Count
                 };
-                memoryCache.Set(key, result, DateTimeOffset.Now.AddMinutes(7));
                 return result;
             }
         }
 
         private async Task<ChannelItemResult> GetVideos(string categoryId, CancellationToken cancellationToken)
         {
-            string key = $"xtream-live-{categoryId}";
-            if (memoryCache.TryGetValue(key, out ChannelItemResult o))
-            {
-                return o;
-            }
-
             Plugin plugin = Plugin.Instance;
             using (XtreamClient client = new XtreamClient())
             {
@@ -192,7 +175,6 @@ namespace Jellyfin.Xtream
                     Items = items,
                     TotalRecordCount = items.Count
                 };
-                memoryCache.Set(key, result, DateTimeOffset.Now.AddMinutes(1));
                 return result;
             }
         }

--- a/Jellyfin.Xtream/SerieChannel.cs
+++ b/Jellyfin.Xtream/SerieChannel.cs
@@ -59,7 +59,7 @@ namespace Jellyfin.Xtream
         public string? Description => "Series streamed from the Xtream-compatible server.";
 
         /// <inheritdoc />
-        public string DataVersion => string.Empty;
+        public string DataVersion => Plugin.Instance.Creds.ToString();
 
         /// <inheritdoc />
         public string HomePageUrl => string.Empty;

--- a/Jellyfin.Xtream/SerieChannel.cs
+++ b/Jellyfin.Xtream/SerieChannel.cs
@@ -28,7 +28,6 @@ using MediaBrowser.Controller.Providers;
 using MediaBrowser.Model.Channels;
 using MediaBrowser.Model.Dto;
 using MediaBrowser.Model.Entities;
-using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 
 namespace Jellyfin.Xtream
@@ -39,17 +38,14 @@ namespace Jellyfin.Xtream
     public class SerieChannel : IChannel
     {
         private readonly ILogger<SerieChannel> logger;
-        private readonly IMemoryCache memoryCache;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SerieChannel"/> class.
         /// </summary>
         /// <param name="logger">Instance of the <see cref="ILogger"/> interface.</param>
-        /// <param name="memoryCache">Instance of the <see cref="IMemoryCache"/> interface.</param>
-        public SerieChannel(ILogger<SerieChannel> logger, IMemoryCache memoryCache)
+        public SerieChannel(ILogger<SerieChannel> logger)
         {
             this.logger = logger;
-            this.memoryCache = memoryCache;
         }
 
         /// <inheritdoc />
@@ -143,12 +139,6 @@ namespace Jellyfin.Xtream
 
         private async Task<ChannelItemResult> GetCategories(CancellationToken cancellationToken)
         {
-            string key = "xtream-series-categories";
-            if (memoryCache.TryGetValue(key, out ChannelItemResult o))
-            {
-                return o;
-            }
-
             Plugin plugin = Plugin.Instance;
             using (XtreamClient client = new XtreamClient())
             {
@@ -172,19 +162,12 @@ namespace Jellyfin.Xtream
                     Items = items,
                     TotalRecordCount = items.Count
                 };
-                memoryCache.Set(key, result, DateTimeOffset.Now.AddMinutes(7));
                 return result;
             }
         }
 
         private async Task<ChannelItemResult> GetSeries(string categoryId, CancellationToken cancellationToken)
         {
-            string key = $"xtream-series-{categoryId}";
-            if (memoryCache.TryGetValue(key, out ChannelItemResult o))
-            {
-                return o;
-            }
-
             Plugin plugin = Plugin.Instance;
             using (XtreamClient client = new XtreamClient())
             {
@@ -214,19 +197,12 @@ namespace Jellyfin.Xtream
                     Items = items,
                     TotalRecordCount = items.Count
                 };
-                memoryCache.Set(key, result, DateTimeOffset.Now.AddMinutes(7));
                 return result;
             }
         }
 
         private async Task<ChannelItemResult> GetSeasons(string seriesId, CancellationToken cancellationToken)
         {
-            string key = $"xtream-seasons-{seriesId}";
-            if (memoryCache.TryGetValue(key, out ChannelItemResult o))
-            {
-                return o;
-            }
-
             Plugin plugin = Plugin.Instance;
             using (XtreamClient client = new XtreamClient())
             {
@@ -276,19 +252,12 @@ namespace Jellyfin.Xtream
                     Items = items,
                     TotalRecordCount = items.Count
                 };
-                memoryCache.Set(key, result, DateTimeOffset.Now.AddMinutes(7));
                 return result;
             }
         }
 
         private async Task<ChannelItemResult> GetEpisodes(string seriesId, int season, CancellationToken cancellationToken)
         {
-            string key = $"xtream-episodes-{seriesId}";
-            if (memoryCache.TryGetValue(key, out ChannelItemResult o))
-            {
-                return o;
-            }
-
             Plugin plugin = Plugin.Instance;
             using (XtreamClient client = new XtreamClient())
             {
@@ -340,7 +309,6 @@ namespace Jellyfin.Xtream
                     Items = items,
                     TotalRecordCount = items.Count
                 };
-                memoryCache.Set(key, result, DateTimeOffset.Now.AddMinutes(1));
                 return result;
             }
         }

--- a/Jellyfin.Xtream/Service/TaskService.cs
+++ b/Jellyfin.Xtream/Service/TaskService.cs
@@ -1,0 +1,76 @@
+// Copyright (C) 2022  Kevin Jilissen
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System;
+using System.Linq;
+using MediaBrowser.Model.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Xtream.Service
+{
+    /// <summary>
+    /// A service for dealing with stream information.
+    /// </summary>
+    public class TaskService
+    {
+        private readonly ILogger logger;
+        private readonly Plugin plugin;
+        private readonly ITaskManager taskManager;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TaskService"/> class.
+        /// </summary>
+        /// <param name="logger">Instance of the <see cref="ILogger"/> interface.</param>
+        /// <param name="plugin">Instance of the <see cref="Plugin"/> class.</param>
+        /// <param name="taskManager">Instance of the <see cref="ITaskManager"/> interface.</param>
+        public TaskService(ILogger logger, Plugin plugin, ITaskManager taskManager)
+        {
+            this.logger = logger;
+            this.plugin = plugin;
+            this.taskManager = taskManager;
+        }
+
+        private static Type? FindType(string assembly, string fullName)
+        {
+            return AppDomain.CurrentDomain.GetAssemblies()
+                .Where(a =>
+                    !a.IsDynamic &&
+                    (a.FullName?.StartsWith($"{assembly},", StringComparison.InvariantCulture) ?? false))
+                .SelectMany(a => a.GetTypes())
+                .FirstOrDefault(t => t?.FullName == fullName);
+        }
+
+        /// <summary>
+        /// Executes a task from the given assembly and name.
+        /// </summary>
+        /// <param name="assembly">The name of the assembly to search in for the type.</param>
+        /// <param name="fullName">The full name of the task type.</param>
+        /// <exception cref="ArgumentException">If the task type is not found.</exception>
+        public void CancelIfRunningAndQueue(string assembly, string fullName)
+        {
+            Type? refreshType = FindType(assembly, fullName);
+            if (refreshType == null)
+            {
+                throw new ArgumentException("Refresh task not found");
+            }
+
+            // As the type is not publicly visible, use reflection.
+            typeof(ITaskManager)
+                .GetMethod(nameof(ITaskManager.CancelIfRunningAndQueue), 1, Array.Empty<Type>())?
+                .MakeGenericMethod(refreshType)?
+                .Invoke(taskManager, Array.Empty<object>());
+        }
+    }
+}

--- a/Jellyfin.Xtream/VodChannel.cs
+++ b/Jellyfin.Xtream/VodChannel.cs
@@ -25,7 +25,6 @@ using MediaBrowser.Controller.Providers;
 using MediaBrowser.Model.Channels;
 using MediaBrowser.Model.Dto;
 using MediaBrowser.Model.Entities;
-using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 
 namespace Jellyfin.Xtream
@@ -36,17 +35,14 @@ namespace Jellyfin.Xtream
     public class VodChannel : IChannel
     {
         private readonly ILogger<VodChannel> logger;
-        private readonly IMemoryCache memoryCache;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="VodChannel"/> class.
         /// </summary>
         /// <param name="logger">Instance of the <see cref="ILogger"/> interface.</param>
-        /// <param name="memoryCache">Instance of the <see cref="IMemoryCache"/> interface.</param>
-        public VodChannel(ILogger<VodChannel> logger, IMemoryCache memoryCache)
+        public VodChannel(ILogger<VodChannel> logger)
         {
             this.logger = logger;
-            this.memoryCache = memoryCache;
         }
 
         /// <inheritdoc />
@@ -113,12 +109,6 @@ namespace Jellyfin.Xtream
 
         private async Task<ChannelItemResult> GetCategories(CancellationToken cancellationToken)
         {
-            string key = "xtream-vod-categories";
-            if (memoryCache.TryGetValue(key, out ChannelItemResult o))
-            {
-                return o;
-            }
-
             Plugin plugin = Plugin.Instance;
             using (XtreamClient client = new XtreamClient())
             {
@@ -142,19 +132,12 @@ namespace Jellyfin.Xtream
                     Items = items,
                     TotalRecordCount = items.Count
                 };
-                memoryCache.Set(key, result, DateTimeOffset.Now.AddMinutes(7));
                 return result;
             }
         }
 
         private async Task<ChannelItemResult> GetVideos(string categoryId, CancellationToken cancellationToken)
         {
-            string key = $"xtream-vod-{categoryId}";
-            if (memoryCache.TryGetValue(key, out ChannelItemResult o))
-            {
-                return o;
-            }
-
             Plugin plugin = Plugin.Instance;
             using (XtreamClient client = new XtreamClient())
             {
@@ -192,7 +175,6 @@ namespace Jellyfin.Xtream
                     Items = items,
                     TotalRecordCount = items.Count
                 };
-                memoryCache.Set(key, result, DateTimeOffset.Now.AddMinutes(1));
                 return result;
             }
         }

--- a/Jellyfin.Xtream/VodChannel.cs
+++ b/Jellyfin.Xtream/VodChannel.cs
@@ -56,7 +56,7 @@ namespace Jellyfin.Xtream
         public string? Description => "Video On-Demand streamed from the Xtream-compatible server.";
 
         /// <inheritdoc />
-        public string DataVersion => string.Empty;
+        public string DataVersion => Plugin.Instance.Creds.ToString();
 
         /// <inheritdoc />
         public string HomePageUrl => string.Empty;


### PR DESCRIPTION
Fix caching issues by using the credentials as cache key and forcing execution of the refresh tasks on configuration change.

Closes #12 