### PR TITLE
Implement Catch-up support

### DIFF
--- a/Jellyfin.Xtream/CatchupChannel.cs
+++ b/Jellyfin.Xtream/CatchupChannel.cs
@@ -171,7 +171,7 @@ namespace Jellyfin.Xtream
                     string dateTitle = epg.Start.ToLocalTime().ToString("ddd HH:mm", CultureInfo.InvariantCulture);
                     List<MediaSourceInfo> sources = new List<MediaSourceInfo>()
                     {
-                        plugin.StreamService.GetMediaSourceInfo(StreamType.CatchUp, channelString, start: epg.Start, durationMinutes: durationMinutes)
+                        plugin.StreamService.GetMediaSourceInfo(StreamType.CatchUp, channelString, start: epg.StartLocalTime, durationMinutes: durationMinutes)
                     };
 
                     items.Add(new ChannelItemInfo()

--- a/Jellyfin.Xtream/Client/Models/EpgInfo.cs
+++ b/Jellyfin.Xtream/Client/Models/EpgInfo.cs
@@ -39,6 +39,9 @@ namespace Jellyfin.Xtream.Client.Models
         [JsonProperty("start_timestamp")]
         public DateTime Start { get; set; }
 
+        [JsonProperty("start")]
+        public DateTime StartLocalTime { get; set; }
+
         [JsonConverter(typeof(UnixDateTimeConverter))]
         [JsonProperty("stop_timestamp")]
         public DateTime End { get; set; }

--- a/Jellyfin.Xtream/Client/Models/StreamInfo.cs
+++ b/Jellyfin.Xtream/Client/Models/StreamInfo.cs
@@ -51,7 +51,7 @@ namespace Jellyfin.Xtream.Client.Models
         public string CustomSid { get; set; } = string.Empty;
 
         [JsonProperty("tv_archive")]
-        public int TvArchive { get; set; }
+        public bool TvArchive { get; set; }
 
         [JsonProperty("direct_source")]
         public string DirectSource { get; set; } = string.Empty;

--- a/Jellyfin.Xtream/Configuration/Web/XtreamLive.js
+++ b/Jellyfin.Xtream/Configuration/Web/XtreamLive.js
@@ -4,6 +4,16 @@ export default function (view) {
     tr.dataset['streamId'] = data.StreamId;
 
     let td = document.createElement('td');
+    if (data.TvArchive) {
+      let span = document.createElement('span');
+      span.ariaHidden = true;
+      span.title = `Catch-up supported for ${data.TvArchiveDuration} days.`;
+      span.className = 'material-icons fiber_manual_record';
+      td.appendChild(span);
+    }
+    tr.appendChild(td);
+
+    td = document.createElement('td');
     td.innerHTML = data.Name;
     tr.appendChild(td);
 

--- a/Jellyfin.Xtream/LiveTvService.cs
+++ b/Jellyfin.Xtream/LiveTvService.cs
@@ -225,7 +225,7 @@ namespace Jellyfin.Xtream
             }
 
             Plugin plugin = Plugin.Instance;
-            MediaSourceInfo mediaSourceInfo = plugin.StreamService.GetMediaSourceInfo(StreamType.Live, channelId, null, true);
+            MediaSourceInfo mediaSourceInfo = plugin.StreamService.GetMediaSourceInfo(StreamType.Live, channelId, restream: true);
             stream = new Restream(appHost, httpClientFactory, logger, mediaSourceInfo);
             return Task.FromResult(stream);
         }

--- a/Jellyfin.Xtream/Service/StreamService.cs
+++ b/Jellyfin.Xtream/Service/StreamService.cs
@@ -158,7 +158,7 @@ namespace Jellyfin.Xtream.Service
 
             if (type == StreamType.CatchUp)
             {
-                string? startString = start?.ToString("o").Replace('T', ':');
+                string? startString = start?.ToString("yyyy'-'MM'-'dd':'HH'-'mm", CultureInfo.InvariantCulture);
                 uri = $"{config.BaseUrl}/streaming/timeshift.php?username={config.Username}&password={config.Password}&stream={id}&start={startString}&duration={durationMinutes}";
             }
 

--- a/Jellyfin.Xtream/Service/StreamService.cs
+++ b/Jellyfin.Xtream/Service/StreamService.cs
@@ -13,6 +13,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Runtime.CompilerServices;
@@ -126,8 +127,16 @@ namespace Jellyfin.Xtream.Service
         /// <param name="id">The unique identifier of the stream.</param>
         /// <param name="extension">The container extension of the stream.</param>
         /// <param name="restream">Boolean indicating whether or not restreaming is used.</param>
+        /// <param name="start">The datetime representing the start time of catcup TV.</param>
+        /// <param name="durationMinutes">The duration in minutes of the catcup TV stream.</param>
         /// <returns>The media source info as <see cref="MediaSourceInfo"/> class.</returns>
-        public MediaSourceInfo GetMediaSourceInfo(StreamType type, string id, string? extension, bool restream = false)
+        public MediaSourceInfo GetMediaSourceInfo(
+            StreamType type,
+            string id,
+            string? extension = null,
+            bool restream = false,
+            DateTime? start = null,
+            int durationMinutes = 0)
         {
             string prefix = string.Empty;
             switch (type)
@@ -145,6 +154,12 @@ namespace Jellyfin.Xtream.Service
             if (!string.IsNullOrEmpty(extension))
             {
                 uri += $".{extension}";
+            }
+
+            if (type == StreamType.CatchUp)
+            {
+                string? startString = start?.ToString("o").Replace('T', ':');
+                uri = $"{config.BaseUrl}/streaming/timeshift.php?username={config.Username}&password={config.Password}&stream={id}&start={startString}&duration={durationMinutes}";
             }
 
             bool isLive = type == StreamType.Live;

--- a/Jellyfin.Xtream/Service/StreamType.cs
+++ b/Jellyfin.Xtream/Service/StreamType.cs
@@ -26,6 +26,11 @@ namespace Jellyfin.Xtream.Service
         Live,
 
         /// <summary>
+        /// Catch up IPTV.
+        /// </summary>
+        CatchUp,
+
+        /// <summary>
         /// On-demand series grouped in seasons and episodes.
         /// </summary>
         Series,


### PR DESCRIPTION
Use EPG information to create a Catch-up channel containing the programs aired during the supported TV archive duration of the configured Live TV channels.

Closes #17 