### PR TITLE
Upgrade to jellyfin 10.8.1 due to breaking change in Jellyfin plugin API.

### DIFF
--- a/Jellyfin.Xtream/Jellyfin.Xtream.csproj
+++ b/Jellyfin.Xtream/Jellyfin.Xtream.csproj
@@ -13,8 +13,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Jellyfin.Controller" Version="10.8-*" />
-    <PackageReference Include="Jellyfin.Model" Version="10.8-*" />
+    <PackageReference Include="Jellyfin.Controller" Version="10.8.1" />
+    <PackageReference Include="Jellyfin.Model" Version="10.8.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 

--- a/build.yaml
+++ b/build.yaml
@@ -2,7 +2,7 @@
 name: "Jellyfin Xtream"
 guid: "5d774c35-8567-46d3-a950-9bb8227a0c5d"
 version: "0.5.0.0"
-targetAbi: "10.8.0.0"
+targetAbi: "10.8.1.0"
 framework: "net6.0"
 overview: "Stream content from an Xtream-compatible server."
 description: >


### PR DESCRIPTION
Closes #25 