### PR TITLE
Fix stream closing with consumer count

### DIFF
--- a/Jellyfin.Xtream/LiveTvService.cs
+++ b/Jellyfin.Xtream/LiveTvService.cs
@@ -217,7 +217,7 @@ public class LiveTvService : ILiveTvService, ISupportsDirectStreamProvider
     }
 
     /// <inheritdoc />
-    public Task<ILiveStream> GetChannelStreamWithDirectStreamProvider(string channelId, string streamId, List<ILiveStream> currentLiveStreams, CancellationToken cancellationToken)
+    public async Task<ILiveStream> GetChannelStreamWithDirectStreamProvider(string channelId, string streamId, List<ILiveStream> currentLiveStreams, CancellationToken cancellationToken)
     {
         Guid guid = Guid.Parse(channelId);
         StreamService.FromGuid(guid, out int prefix, out int channel, out int _, out int _);
@@ -233,9 +233,10 @@ public class LiveTvService : ILiveTvService, ISupportsDirectStreamProvider
         if (stream == null)
         {
             stream = new Restream(appHost, httpClientFactory, logger, mediaSourceInfo);
+            await stream.Open(cancellationToken).ConfigureAwait(false);
         }
 
         stream.ConsumerCount++;
-        return Task.FromResult(stream);
+        return stream;
     }
 }

--- a/Jellyfin.Xtream/LiveTvService.cs
+++ b/Jellyfin.Xtream/LiveTvService.cs
@@ -229,12 +229,13 @@ public class LiveTvService : ILiveTvService, ISupportsDirectStreamProvider
         Plugin plugin = Plugin.Instance;
         MediaSourceInfo mediaSourceInfo = plugin.StreamService.GetMediaSourceInfo(StreamType.Live, channel, restream: true);
         ILiveStream? stream = currentLiveStreams.Find(stream => stream.TunerHostId == Restream.TunerHost && stream.MediaSource.Id == mediaSourceInfo.Id);
-        if (stream != null)
+
+        if (stream == null)
         {
-            return Task.FromResult(stream);
+            stream = new Restream(appHost, httpClientFactory, logger, mediaSourceInfo);
         }
 
-        stream = new Restream(appHost, httpClientFactory, logger, mediaSourceInfo);
+        stream.ConsumerCount++;
         return Task.FromResult(stream);
     }
 }

--- a/Jellyfin.Xtream/Service/Restream.cs
+++ b/Jellyfin.Xtream/Service/Restream.cs
@@ -59,7 +59,6 @@ public class Restream : ILiveStream, IDisposable
     private Task? copyTask;
     private Stream? inputStream;
 
-    private int consumerCount;
     private string originalStreamId;
     private MediaSourceInfo mediaSource;
 
@@ -92,7 +91,7 @@ public class Restream : ILiveStream, IDisposable
     }
 
     /// <inheritdoc />
-    public int ConsumerCount { get => consumerCount; set => consumerCount = value; }
+    public int ConsumerCount { get; set; }
 
     /// <inheritdoc />
     public string OriginalStreamId { get => originalStreamId; set => originalStreamId = value; }
@@ -171,9 +170,8 @@ public class Restream : ILiveStream, IDisposable
             _ = Open(CancellationToken.None);
         }
 
-        consumerCount++;
-        logger.LogInformation("Opening restream {Count} for channel {ChannelId}.", consumerCount, mediaSource.Id);
         return new WrappedBufferReadStream(buffer);
+        logger.LogInformation("Opening restream {Count} for channel {ChannelId}.", ConsumerCount, mediaSource.Id);
     }
 
     /// <summary>


### PR DESCRIPTION
Jellyfin kept the stream to the Xtream API open for Live TV, due to a misinterpretation of the consumer count.