### PR TITLE
Fixed Error when air_date is "null"

### DIFF
--- a/Jellyfin.Xtream/Client/Models/Season.cs
+++ b/Jellyfin.Xtream/Client/Models/Season.cs
@@ -21,8 +21,28 @@ namespace Jellyfin.Xtream.Client.Models;
 
 public class Season
 {
-    [JsonProperty("air_date")]
-    public DateTime AirDate { get; set; }
+    [JsonProperty("air_date", NullValueHandling = NullValueHandling.Ignore)]
+    private string? _airDate;
+
+    public DateTime AirDate
+    {
+        get
+        {
+            if (DateTime.TryParse(_airDate, out var parsedDate))
+            {
+                return parsedDate;
+            }
+
+            return DateTime.MinValue; // Default value if parsing fails
+        }
+
+        set
+        {
+#pragma warning disable CA1305
+            _airDate = value.ToString("yyyy-MM-dd");
+#pragma warning restore CA1305
+        }
+    }
 
     [JsonProperty("episode_count")]
     public int EpisodeCount { get; set; }


### PR DESCRIPTION
Some Providers dont fill the "air_date" in Json or leave it "null" which results in an Empty Series.
To avoid that we guss that "air_date" is a String and Convert it to DateTime if it not equals "null"