### PR TITLE
fix: handle null case in SingularToListConverter

### DIFF
--- a/Jellyfin.Xtream/Client/SingularToListConverter.cs
+++ b/Jellyfin.Xtream/Client/SingularToListConverter.cs
@@ -53,6 +53,8 @@ public class SingularToListConverter<T> : JsonConverter
                 }
 
                 goto default;
+            case JsonToken.Null:
+                return [];
             default:
                 throw new JsonReaderException("The JsonReader points to an unexpected point.");
         }


### PR DESCRIPTION
Allowing null interpretation as empty collection