### PR TITLE
Start the restream read head half a buffer back

### DIFF
--- a/Jellyfin.Xtream/Service/WrappedBufferReadStream.cs
+++ b/Jellyfin.Xtream/Service/WrappedBufferReadStream.cs
@@ -35,7 +35,7 @@ public class WrappedBufferReadStream : Stream
     public WrappedBufferReadStream(WrappedBufferStream sourceBuffer)
     {
         _sourceBuffer = sourceBuffer;
-        _initialReadHead = sourceBuffer.TotalBytesWritten;
+        _initialReadHead = Math.Max(0, sourceBuffer.TotalBytesWritten - (sourceBuffer.BufferSize / 2));
         ReadHead = _initialReadHead;
     }
 


### PR DESCRIPTION
This allows for faster buffering and transcode starting, as the upstream server often sends some buffered data before the clients connect.