### PR TITLE
added user-configurable catchup syntax

### DIFF
--- a/Jellyfin.Xtream/Client/Models/Category.cs
+++ b/Jellyfin.Xtream/Client/Models/Category.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2022  Kevin Jilissen
+// Copyright (C) 2022  Kevin Jilissen
 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/Jellyfin.Xtream/Client/Models/PlayerApi.cs
+++ b/Jellyfin.Xtream/Client/Models/PlayerApi.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2022  Kevin Jilissen
+// Copyright (C) 2022  Kevin Jilissen
 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/Jellyfin.Xtream/Client/Models/ServerInfo.cs
+++ b/Jellyfin.Xtream/Client/Models/ServerInfo.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2022  Kevin Jilissen
+// Copyright (C) 2022  Kevin Jilissen
 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/Jellyfin.Xtream/Client/Models/StreamInfo.cs
+++ b/Jellyfin.Xtream/Client/Models/StreamInfo.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2022  Kevin Jilissen
+// Copyright (C) 2022  Kevin Jilissen
 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/Jellyfin.Xtream/Client/Models/UserInfo.cs
+++ b/Jellyfin.Xtream/Client/Models/UserInfo.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2022  Kevin Jilissen
+// Copyright (C) 2022  Kevin Jilissen
 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/Jellyfin.Xtream/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Xtream/Configuration/PluginConfiguration.cs
@@ -60,6 +60,11 @@ public class PluginConfiguration : BasePluginConfiguration
     public bool IsTmdbVodOverride { get; set; } = true;
 
     /// <summary>
+    /// Gets or sets the format for the catch-up URL.
+    /// </summary>
+    public string CatchupUrlFormat { get; set; } = "{0}/streaming/timeshift.php?username={1}&password={2}&stream={3}&start={4}&duration={5}";
+
+    /// <summary>
     /// Gets or sets the channels displayed in Live TV.
     /// </summary>
     public SerializableDictionary<int, HashSet<int>> LiveTv { get; set; } = [];

--- a/Jellyfin.Xtream/Configuration/Web/XtreamCredentials.html
+++ b/Jellyfin.Xtream/Configuration/Web/XtreamCredentials.html
@@ -20,6 +20,13 @@
           <input id="Password" name="Password" type="password" is="emby-input" />
           <div class="fieldDescription">The password.</div>
         </div>
+        <div class="inputContainer">
+          <label class="inputLabel inputLabelUnfocused" for="CatchupUrlFormat">Catch-up URL Format</label>
+          <input id="CatchupUrlFormat" name="CatchupUrlFormat" type="text" is="emby-input" />
+          <div class="fieldDescription">
+            URL format for catch-up streams. Placeholders: {0}=BaseUrl, {1}=Username, {2}=Password, {3}=StreamID, {4}=StartTime, {5}=Duration.
+          </div>
+        </div>
         <div>
           <button is="emby-button" type="submit" class="raised button-submit block emby-button">
             <span>Save</span>

--- a/Jellyfin.Xtream/Configuration/Web/XtreamCredentials.js
+++ b/Jellyfin.Xtream/Configuration/Web/XtreamCredentials.js
@@ -13,6 +13,7 @@ export default function (view) {
       view.querySelector('#BaseUrl').value = config.BaseUrl;
       view.querySelector('#Username').value = config.Username;
       view.querySelector('#Password').value = config.Password;
+      view.querySelector('#CatchupUrlFormat').value = config.CatchupUrlFormat || '{0}/streaming/timeshift.php?username={1}&password={2}&stream={3}&start={4}&duration={5}';
       Dashboard.hideLoadingMsg();
     });
 
@@ -52,6 +53,7 @@ export default function (view) {
         config.BaseUrl = view.querySelector('#BaseUrl').value;
         config.Username = view.querySelector('#Username').value;
         config.Password = view.querySelector('#Password').value;
+        config.CatchupUrlFormat = view.querySelector('#CatchupUrlFormat').value;
         ApiClient.updatePluginConfiguration(pluginId, config).then((result) => {
           reloadStatus();
           Dashboard.processPluginConfigurationUpdateResult(result);

--- a/Jellyfin.Xtream/Service/StreamService.cs
+++ b/Jellyfin.Xtream/Service/StreamService.cs
@@ -389,7 +389,7 @@ public partial class StreamService(IXtreamClient xtreamClient)
         if (type == StreamType.CatchUp)
         {
             string? startString = start?.ToString("yyyy'-'MM'-'dd':'HH'-'mm", CultureInfo.InvariantCulture);
-            uri = $"{config.BaseUrl}/streaming/timeshift.php?username={config.Username}&password={config.Password}&stream={id}&start={startString}&duration={durationMinutes}";
+            uri = string.Format(CultureInfo.InvariantCulture, config.CatchupUrlFormat, config.BaseUrl, config.Username, config.Password, id, startString, durationMinutes);
         }
 
         bool isLive = type == StreamType.Live;

--- a/repo_contents.txt
+++ b/repo_contents.txt
@@ -1,0 +1,6723 @@
+--- DIRECTORY STRUCTURE ---
+.
+├── build.yaml
+├── jellyfin.ruleset
+├── Jellyfin.Xtream
+│   ├── Api
+│   │   ├── Models
+│   │   │   ├── CategoryResponse.cs
+│   │   │   ├── ChannelResponse.cs
+│   │   │   ├── ItemResponse.cs
+│   │   │   └── ProviderTestResponse.cs
+│   │   └── XtreamController.cs
+│   ├── CatchupChannel.cs
+│   ├── Client
+│   │   ├── Base64Converter.cs
+│   │   ├── ConnectionInfo.cs
+│   │   ├── IXtreamClient.cs
+│   │   ├── Models
+│   │   │   ├── AudioInfo.cs
+│   │   │   ├── Category.cs
+│   │   │   ├── EpgInfo.cs
+│   │   │   ├── EpgListings.cs
+│   │   │   ├── Episode.cs
+│   │   │   ├── EpisodeInfo.cs
+│   │   │   ├── PlayerApi.cs
+│   │   │   ├── Season.cs
+│   │   │   ├── Series.cs
+│   │   │   ├── SeriesInfo.cs
+│   │   │   ├── SeriesStreamInfo.cs
+│   │   │   ├── ServerInfo.cs
+│   │   │   ├── StreamInfo.cs
+│   │   │   ├── UserInfo.cs
+│   │   │   ├── VideoInfo.cs
+│   │   │   ├── VodInfo.cs
+│   │   │   └── VodStreamInfo.cs
+│   │   ├── OnlyObjectConverter.cs
+│   │   ├── SingularToListConverter.cs
+│   │   ├── StringBoolConverter.cs
+│   │   └── XtreamClient.cs
+│   ├── Configuration
+│   │   ├── ChannelOverrides.cs
+│   │   ├── PluginConfiguration.cs
+│   │   ├── SerializableDictionary.cs
+│   │   └── Web
+│   │       ├── XtreamCredentials.html
+│   │       ├── XtreamCredentials.js
+│   │       ├── Xtream.css
+│   │       ├── Xtream.js
+│   │       ├── XtreamLive.html
+│   │       ├── XtreamLive.js
+│   │       ├── XtreamLiveOverrides.html
+│   │       ├── XtreamLiveOverrides.js
+│   │       ├── XtreamSeries.html
+│   │       ├── XtreamSeries.js
+│   │       ├── XtreamVod.html
+│   │       └── XtreamVod.js
+│   ├── Jellyfin.Xtream.csproj
+│   ├── LiveTvService.cs
+│   ├── Plugin.cs
+│   ├── PluginServiceRegistrator.cs
+│   ├── Providers
+│   │   └── XtreamVodProvider.cs
+│   ├── SeriesChannel.cs
+│   ├── Service
+│   │   ├── ParsedName.cs
+│   │   ├── Restream.cs
+│   │   ├── StreamService.cs
+│   │   ├── StreamType.cs
+│   │   ├── TaskService.cs
+│   │   ├── WrappedBufferReadStream.cs
+│   │   └── WrappedBufferStream.cs
+│   └── VodChannel.cs
+├── Jellyfin.Xtream.sln
+├── LICENSE
+├── README.md
+└── repo_contents.txt
+
+10 directories, 65 files
+
+--- FILE CONTENTS ---
+--- START OF FILE: ./repo_contents.txt ---
+--- END OF FILE: ./repo_contents.txt ---
+
+--- START OF FILE: ./.gitignore ---
+bin/
+obj/
+.vs/
+.idea/
+.vscode/
+artifacts
+--- END OF FILE: ./.gitignore ---
+
+--- START OF FILE: ./Jellyfin.Xtream/CatchupChannel.cs ---
+// Copyright (C) 2022  Kevin Jilissen
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Xtream.Client;
+using Jellyfin.Xtream.Client.Models;
+using Jellyfin.Xtream.Service;
+using MediaBrowser.Controller.Channels;
+using MediaBrowser.Controller.Providers;
+using MediaBrowser.Model.Channels;
+using MediaBrowser.Model.Dto;
+using MediaBrowser.Model.Entities;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Xtream;
+
+/// <summary>
+/// The Xtream Codes API channel.
+/// </summary>
+/// <param name="logger">Instance of the <see cref="ILogger"/> interface.</param>
+/// <param name="xtreamClient">Instance of the <see cref="IXtreamClient"/> interface.</param>
+public class CatchupChannel(ILogger<CatchupChannel> logger, IXtreamClient xtreamClient) : IChannel, IDisableMediaSourceDisplay
+{
+    private readonly ILogger<CatchupChannel> _logger = logger;
+
+    /// <inheritdoc />
+    public string? Name => "Xtream Catch-up";
+
+    /// <inheritdoc />
+    public string? Description => "Rewatch IPTV streamed from the Xtream-compatible server.";
+
+    /// <inheritdoc />
+    public string DataVersion => Plugin.Instance.DataVersion + DateTime.Today.ToShortDateString();
+
+    /// <inheritdoc />
+    public string HomePageUrl => string.Empty;
+
+    /// <inheritdoc />
+    public ChannelParentalRating ParentalRating => ChannelParentalRating.GeneralAudience;
+
+    /// <inheritdoc />
+    public InternalChannelFeatures GetChannelFeatures()
+    {
+        return new InternalChannelFeatures
+        {
+            ContentTypes = [
+                ChannelMediaContentType.TvExtra,
+            ],
+            MediaTypes = [
+                ChannelMediaType.Video
+            ],
+        };
+    }
+
+    /// <inheritdoc />
+    public Task<DynamicImageResponse> GetChannelImage(ImageType type, CancellationToken cancellationToken)
+    {
+        switch (type)
+        {
+            default:
+                throw new ArgumentException("Unsupported image type: " + type);
+        }
+    }
+
+    /// <inheritdoc />
+    public IEnumerable<ImageType> GetSupportedChannelImages() => new List<ImageType>
+    {
+        // ImageType.Primary
+    };
+
+    /// <inheritdoc />
+    public async Task<ChannelItemResult> GetChannelItems(InternalChannelItemQuery query, CancellationToken cancellationToken)
+    {
+        try
+        {
+            if (string.IsNullOrEmpty(query.FolderId))
+            {
+                return await GetChannels(cancellationToken).ConfigureAwait(false);
+            }
+
+            Guid guid = Guid.Parse(query.FolderId);
+            StreamService.FromGuid(guid, out int prefix, out int categoryId, out int channelId, out int date);
+
+            if (date == 0)
+            {
+                return await GetDays(categoryId, channelId, cancellationToken).ConfigureAwait(false);
+            }
+
+            return await GetStreams(categoryId, channelId, date, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to get channel items");
+            throw;
+        }
+    }
+
+    private async Task<ChannelItemResult> GetChannels(CancellationToken cancellationToken)
+    {
+        Plugin plugin = Plugin.Instance;
+        List<ChannelItemInfo> items = [];
+        foreach (StreamInfo channel in await plugin.StreamService.GetLiveStreamsWithOverrides(cancellationToken).ConfigureAwait(false))
+        {
+            if (!channel.TvArchive)
+            {
+                // Channel has no catch-up support.
+                continue;
+            }
+
+            ParsedName parsedName = StreamService.ParseName(channel.Name);
+            items.Add(new ChannelItemInfo()
+            {
+                Id = StreamService.ToGuid(StreamService.CatchupPrefix, channel.CategoryId ?? 0, channel.StreamId, 0).ToString(),
+                ImageUrl = channel.StreamIcon,
+                Name = parsedName.Title,
+                Tags = new List<string>(parsedName.Tags),
+                Type = ChannelItemType.Folder,
+            });
+        }
+
+        ChannelItemResult result = new ChannelItemResult()
+        {
+            Items = items,
+            TotalRecordCount = items.Count
+        };
+        return result;
+    }
+
+    private async Task<ChannelItemResult> GetDays(int categoryId, int channelId, CancellationToken cancellationToken)
+    {
+        Plugin plugin = Plugin.Instance;
+
+        List<StreamInfo> streams = await xtreamClient.GetLiveStreamsByCategoryAsync(plugin.Creds, categoryId, cancellationToken).ConfigureAwait(false);
+        StreamInfo channel = streams.FirstOrDefault(s => s.StreamId == channelId)
+            ?? throw new ArgumentException($"Channel with id {channelId} not found in category {categoryId}");
+        ParsedName parsedName = StreamService.ParseName(channel.Name);
+
+        List<ChannelItemInfo> items = [];
+        for (int i = 0; i <= channel.TvArchiveDuration; i++)
+        {
+            DateTime channelDay = DateTime.Today.AddDays(-i);
+            int day = (int)(channelDay - DateTime.UnixEpoch).TotalDays;
+            items.Add(new()
+            {
+                Id = StreamService.ToGuid(StreamService.CatchupPrefix, channel.CategoryId ?? 0, channel.StreamId, day).ToString(),
+                ImageUrl = channel.StreamIcon,
+                Name = channelDay.ToLocalTime().ToString("ddd dd'-'MM'-'yyyy", CultureInfo.InvariantCulture),
+                Tags = new List<string>(parsedName.Tags),
+                Type = ChannelItemType.Folder,
+            });
+        }
+
+        ChannelItemResult result = new()
+        {
+            Items = items,
+            TotalRecordCount = items.Count
+        };
+        return result;
+    }
+
+    private async Task<ChannelItemResult> GetStreams(int categoryId, int channelId, int day, CancellationToken cancellationToken)
+    {
+        DateTime start = DateTime.UnixEpoch.AddDays(day);
+        DateTime end = start.AddDays(1);
+        Plugin plugin = Plugin.Instance;
+
+        List<StreamInfo> streams = await xtreamClient.GetLiveStreamsByCategoryAsync(plugin.Creds, categoryId, cancellationToken).ConfigureAwait(false);
+        StreamInfo channel = streams.FirstOrDefault(s => s.StreamId == channelId)
+            ?? throw new ArgumentException($"Channel with id {channelId} not found in category {categoryId}");
+        EpgListings epgs = await xtreamClient.GetEpgInfoAsync(plugin.Creds, channelId, cancellationToken).ConfigureAwait(false);
+        List<ChannelItemInfo> items = [];
+
+        // Create fallback single-stream catch-up if no EPG is available.
+        if (epgs.Listings.Count == 0)
+        {
+            int durationMinutes = 24 * 60;
+            return new()
+            {
+                Items = new List<ChannelItemInfo>()
+                    {
+                        new()
+                        {
+                            ContentType = ChannelMediaContentType.TvExtra,
+                            Id = StreamService.ToGuid(StreamService.CatchupStreamPrefix, channelId, 0, day).ToString(),
+                            IsLiveStream = false,
+                            MediaSources = [
+                                plugin.StreamService.GetMediaSourceInfo(StreamType.CatchUp, channelId, start: start, durationMinutes: durationMinutes)
+                            ],
+                            MediaType = ChannelMediaType.Video,
+                            Name = $"No EPG available",
+                            RunTimeTicks = durationMinutes * TimeSpan.TicksPerMinute,
+                            Type = ChannelItemType.Media,
+                        }
+                    },
+                TotalRecordCount = 1
+            };
+        }
+
+        foreach (EpgInfo epg in epgs.Listings.Where(epg => epg.Start <= end && epg.End >= start))
+        {
+            ParsedName parsedName = StreamService.ParseName(epg.Title);
+            int durationMinutes = (int)Math.Ceiling((epg.End - epg.Start).TotalMinutes);
+            string dateTitle = epg.Start.ToLocalTime().ToString("HH:mm", CultureInfo.InvariantCulture);
+            List<MediaSourceInfo> sources = [
+                plugin.StreamService.GetMediaSourceInfo(StreamType.CatchUp, channelId, start: epg.StartLocalTime, durationMinutes: durationMinutes)
+            ];
+
+            items.Add(new()
+            {
+                ContentType = ChannelMediaContentType.TvExtra,
+                DateCreated = epg.Start,
+                Id = StreamService.ToGuid(StreamService.CatchupStreamPrefix, channel.StreamId, epg.Id, day).ToString(),
+                IsLiveStream = false,
+                MediaSources = sources,
+                MediaType = ChannelMediaType.Video,
+                Name = $"{dateTitle} - {parsedName.Title}",
+                Overview = epg.Description,
+                PremiereDate = epg.Start,
+                RunTimeTicks = durationMinutes * TimeSpan.TicksPerMinute,
+                Tags = new List<string>(parsedName.Tags),
+                Type = ChannelItemType.Media,
+            });
+        }
+
+        ChannelItemResult result = new()
+        {
+            Items = items,
+            TotalRecordCount = items.Count
+        };
+        return result;
+    }
+
+    /// <inheritdoc />
+    public bool IsEnabledFor(string userId)
+    {
+        return Plugin.Instance.Configuration.IsCatchupVisible;
+    }
+}
+--- END OF FILE: ./Jellyfin.Xtream/CatchupChannel.cs ---
+
+--- START OF FILE: ./Jellyfin.Xtream/PluginServiceRegistrator.cs ---
+// Copyright (C) 2022  Kevin Jilissen
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using Jellyfin.Xtream.Client;
+using Jellyfin.Xtream.Providers;
+using MediaBrowser.Controller;
+using MediaBrowser.Controller.Channels;
+using MediaBrowser.Controller.LiveTv;
+using MediaBrowser.Controller.Plugins;
+using MediaBrowser.Controller.Providers;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Jellyfin.Xtream;
+
+/// <inheritdoc />
+public class PluginServiceRegistrator : IPluginServiceRegistrator
+{
+    /// <inheritdoc />
+    public void RegisterServices(IServiceCollection serviceCollection, IServerApplicationHost applicationHost)
+    {
+        serviceCollection.AddSingleton<IXtreamClient, XtreamClient>();
+        serviceCollection.AddSingleton<ILiveTvService, LiveTvService>();
+        serviceCollection.AddSingleton<IChannel, CatchupChannel>();
+        serviceCollection.AddSingleton<IChannel, SeriesChannel>();
+        serviceCollection.AddSingleton<IChannel, VodChannel>();
+        serviceCollection.AddSingleton<IPreRefreshProvider, XtreamVodProvider>();
+    }
+}
+--- END OF FILE: ./Jellyfin.Xtream/PluginServiceRegistrator.cs ---
+
+--- START OF FILE: ./Jellyfin.Xtream/LiveTvService.cs ---
+// Copyright (C) 2022  Kevin Jilissen
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Xtream.Client;
+using Jellyfin.Xtream.Client.Models;
+using Jellyfin.Xtream.Service;
+using MediaBrowser.Controller;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.LiveTv;
+using MediaBrowser.Model.Dto;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Xtream;
+
+/// <summary>
+/// Class LiveTvService.
+/// </summary>
+/// <remarks>
+/// Initializes a new instance of the <see cref="LiveTvService"/> class.
+/// </remarks>
+/// <param name="appHost">Instance of the <see cref="IServerApplicationHost"/> interface.</param>
+/// <param name="httpClientFactory">Instance of the <see cref="IHttpClientFactory"/> interface.</param>
+/// <param name="logger">Instance of the <see cref="ILogger"/> interface.</param>
+/// <param name="memoryCache">Instance of the <see cref="IMemoryCache"/> interface.</param>
+/// <param name="xtreamClient">Instance of the <see cref="IXtreamClient"/> interface.</param>
+public class LiveTvService(IServerApplicationHost appHost, IHttpClientFactory httpClientFactory, ILogger<LiveTvService> logger, IMemoryCache memoryCache, IXtreamClient xtreamClient) : ILiveTvService, ISupportsDirectStreamProvider
+{
+    /// <inheritdoc />
+    public string Name => "Xtream Live";
+
+    /// <inheritdoc />
+    public string HomePageUrl => string.Empty;
+
+    /// <inheritdoc />
+    public async Task<IEnumerable<ChannelInfo>> GetChannelsAsync(CancellationToken cancellationToken)
+    {
+        Plugin plugin = Plugin.Instance;
+        List<ChannelInfo> items = [];
+        foreach (StreamInfo channel in await plugin.StreamService.GetLiveStreamsWithOverrides(cancellationToken).ConfigureAwait(false))
+        {
+            ParsedName parsed = StreamService.ParseName(channel.Name);
+            items.Add(new ChannelInfo()
+            {
+                Id = StreamService.ToGuid(StreamService.LiveTvPrefix, channel.StreamId, 0, 0).ToString(),
+                Number = channel.Num.ToString(CultureInfo.InvariantCulture),
+                ImageUrl = channel.StreamIcon,
+                Name = parsed.Title,
+                Tags = parsed.Tags,
+            });
+        }
+
+        return items;
+    }
+
+    /// <inheritdoc />
+    public Task CancelTimerAsync(string timerId, CancellationToken cancellationToken)
+    {
+        throw new NotImplementedException();
+    }
+
+    /// <inheritdoc />
+    public Task CreateTimerAsync(TimerInfo info, CancellationToken cancellationToken)
+    {
+        throw new NotImplementedException();
+    }
+
+    /// <inheritdoc />
+    public Task<IEnumerable<TimerInfo>> GetTimersAsync(CancellationToken cancellationToken)
+    {
+        return Task.FromResult<IEnumerable<TimerInfo>>(new List<TimerInfo>());
+    }
+
+    /// <inheritdoc />
+    public Task<IEnumerable<SeriesTimerInfo>> GetSeriesTimersAsync(CancellationToken cancellationToken)
+    {
+        return Task.FromResult<IEnumerable<SeriesTimerInfo>>(new List<SeriesTimerInfo>());
+    }
+
+    /// <inheritdoc />
+    public Task CreateSeriesTimerAsync(SeriesTimerInfo info, CancellationToken cancellationToken)
+    {
+        throw new NotImplementedException();
+    }
+
+    /// <inheritdoc />
+    public Task UpdateSeriesTimerAsync(SeriesTimerInfo info, CancellationToken cancellationToken)
+    {
+        throw new NotImplementedException();
+    }
+
+    /// <inheritdoc />
+    public Task UpdateTimerAsync(TimerInfo updatedTimer, CancellationToken cancellationToken)
+    {
+        throw new NotImplementedException();
+    }
+
+    /// <inheritdoc />
+    public Task CancelSeriesTimerAsync(string timerId, CancellationToken cancellationToken)
+    {
+        throw new NotImplementedException();
+    }
+
+    /// <inheritdoc />
+    public async Task<List<MediaSourceInfo>> GetChannelStreamMediaSources(string channelId, CancellationToken cancellationToken)
+    {
+        MediaSourceInfo source = await GetChannelStream(channelId, string.Empty, cancellationToken).ConfigureAwait(false);
+        return [source];
+    }
+
+    /// <inheritdoc />
+    public Task<MediaSourceInfo> GetChannelStream(string channelId, string streamId, CancellationToken cancellationToken)
+    {
+        throw new NotImplementedException();
+    }
+
+    /// <inheritdoc />
+    public Task CloseLiveStream(string id, CancellationToken cancellationToken)
+    {
+        logger.LogInformation("Closing livestream {ChannelId}", id);
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public Task<SeriesTimerInfo> GetNewTimerDefaultsAsync(CancellationToken cancellationToken, ProgramInfo? program = null)
+    {
+        return Task.FromResult(new SeriesTimerInfo
+        {
+            PostPaddingSeconds = 120,
+            PrePaddingSeconds = 120,
+            RecordAnyChannel = false,
+            RecordAnyTime = true,
+            RecordNewOnly = false
+        });
+    }
+
+    /// <inheritdoc />
+    public async Task<IEnumerable<ProgramInfo>> GetProgramsAsync(string channelId, DateTime startDateUtc, DateTime endDateUtc, CancellationToken cancellationToken)
+    {
+        Guid guid = Guid.Parse(channelId);
+        StreamService.FromGuid(guid, out int prefix, out int streamId, out int _, out int _);
+        if (prefix != StreamService.LiveTvPrefix)
+        {
+            throw new ArgumentException("Unsupported channel");
+        }
+
+        string key = $"xtream-epg-{channelId}";
+        ICollection<ProgramInfo>? items = null;
+        if (memoryCache.TryGetValue(key, out ICollection<ProgramInfo>? o))
+        {
+            items = o;
+        }
+        else
+        {
+            items = new List<ProgramInfo>();
+            Plugin plugin = Plugin.Instance;
+            {
+                EpgListings epgs = await xtreamClient.GetEpgInfoAsync(plugin.Creds, streamId, cancellationToken).ConfigureAwait(false);
+                foreach (EpgInfo epg in epgs.Listings)
+                {
+                    items.Add(new()
+                    {
+                        Id = StreamService.ToGuid(StreamService.EpgPrefix, streamId, epg.Id, 0).ToString(),
+                        ChannelId = channelId,
+                        StartDate = epg.Start,
+                        EndDate = epg.End,
+                        Name = epg.Title,
+                        Overview = epg.Description,
+                    });
+                }
+            }
+
+            memoryCache.Set(key, items, DateTimeOffset.Now.AddMinutes(10));
+        }
+
+        return from epg in items
+               where epg.EndDate >= startDateUtc && epg.StartDate < endDateUtc
+               select epg;
+    }
+
+    /// <inheritdoc />
+    public Task ResetTuner(string id, CancellationToken cancellationToken)
+    {
+        throw new NotImplementedException();
+    }
+
+    /// <inheritdoc />
+    public async Task<ILiveStream> GetChannelStreamWithDirectStreamProvider(string channelId, string streamId, List<ILiveStream> currentLiveStreams, CancellationToken cancellationToken)
+    {
+        Guid guid = Guid.Parse(channelId);
+        StreamService.FromGuid(guid, out int prefix, out int channel, out int _, out int _);
+        if (prefix != StreamService.LiveTvPrefix)
+        {
+            throw new ArgumentException("Unsupported channel");
+        }
+
+        Plugin plugin = Plugin.Instance;
+        MediaSourceInfo mediaSourceInfo = plugin.StreamService.GetMediaSourceInfo(StreamType.Live, channel, restream: true);
+        ILiveStream? stream = currentLiveStreams.Find(stream => stream.TunerHostId == Restream.TunerHost && stream.MediaSource.Id == mediaSourceInfo.Id);
+
+        if (stream == null)
+        {
+            stream = new Restream(appHost, httpClientFactory, logger, mediaSourceInfo);
+            await stream.Open(cancellationToken).ConfigureAwait(false);
+        }
+
+        stream.ConsumerCount++;
+        return stream;
+    }
+}
+--- END OF FILE: ./Jellyfin.Xtream/LiveTvService.cs ---
+
+--- START OF FILE: ./Jellyfin.Xtream/Client/StringBoolConverter.cs ---
+// Copyright (C) 2022  Kevin Jilissen
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System;
+using System.Text;
+using Newtonsoft.Json;
+
+namespace Jellyfin.Xtream.Client;
+
+/// <summary>
+/// Class StringBoolConverter converts strings from and to base64.
+/// </summary>
+public class StringBoolConverter : JsonConverter
+{
+    /// <inheritdoc />
+    public override bool CanConvert(Type objectType)
+    {
+        return objectType == typeof(string);
+    }
+
+    /// <inheritdoc />
+    public override object ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
+    {
+        if (reader.Value == null)
+        {
+            throw new ArgumentException("Value cannot be null.");
+        }
+
+        return "1".Equals((string)reader.Value, StringComparison.Ordinal);
+    }
+
+    /// <inheritdoc />
+    public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
+    {
+        if (value == null)
+        {
+            throw new ArgumentException("Value cannot be null.");
+        }
+
+        string result = (bool)value ? "1" : "0";
+        writer.WriteValue(result);
+    }
+}
+--- END OF FILE: ./Jellyfin.Xtream/Client/StringBoolConverter.cs ---
+
+--- START OF FILE: ./Jellyfin.Xtream/Client/ConnectionInfo.cs ---
+// Copyright (C) 2022  Kevin Jilissen
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+namespace Jellyfin.Xtream.Client;
+
+/// <summary>
+/// A wrapper class for Xtream API client connection information.
+/// </summary>
+/// <param name="baseUrl">The base url including protocol and port number, without trailing slash.</param>
+/// <param name="username">The username for authentication.</param>
+/// <param name="password">The password for authentication.</param>
+public class ConnectionInfo(string baseUrl, string username, string password)
+{
+    /// <summary>
+    /// Gets or sets the base url including protocol and port number, without trailing slash.
+    /// </summary>
+    public string BaseUrl { get; set; } = baseUrl;
+
+    /// <summary>
+    /// Gets or sets the username for authentication.
+    /// </summary>
+    public string UserName { get; set; } = username;
+
+    /// <summary>
+    /// Gets or sets the password for authentication.
+    /// </summary>
+    public string Password { get; set; } = password;
+
+    /// <inheritdoc />
+    public override string ToString() => $"{BaseUrl} {UserName}:{Password}";
+}
+--- END OF FILE: ./Jellyfin.Xtream/Client/ConnectionInfo.cs ---
+
+--- START OF FILE: ./Jellyfin.Xtream/Client/IXtreamClient.cs ---
+// Copyright (C) 2022  Kevin Jilissen
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Xtream.Client.Models;
+
+#pragma warning disable CS1591
+namespace Jellyfin.Xtream.Client;
+
+public interface IXtreamClient
+{
+    Task<EpgListings> GetEpgInfoAsync(ConnectionInfo connectionInfo, int streamId, CancellationToken cancellationToken);
+
+    Task<List<Category>> GetLiveCategoryAsync(ConnectionInfo connectionInfo, CancellationToken cancellationToken);
+
+    Task<List<StreamInfo>> GetLiveStreamsAsync(ConnectionInfo connectionInfo, CancellationToken cancellationToken);
+
+    Task<List<StreamInfo>> GetLiveStreamsByCategoryAsync(ConnectionInfo connectionInfo, int categoryId, CancellationToken cancellationToken);
+
+    Task<List<Series>> GetSeriesByCategoryAsync(ConnectionInfo connectionInfo, int categoryId, CancellationToken cancellationToken);
+
+    Task<List<Category>> GetSeriesCategoryAsync(ConnectionInfo connectionInfo, CancellationToken cancellationToken);
+
+    Task<SeriesStreamInfo> GetSeriesStreamsBySeriesAsync(ConnectionInfo connectionInfo, int seriesId, CancellationToken cancellationToken);
+
+    Task<PlayerApi> GetUserAndServerInfoAsync(ConnectionInfo connectionInfo, CancellationToken cancellationToken);
+
+    Task<List<Category>> GetVodCategoryAsync(ConnectionInfo connectionInfo, CancellationToken cancellationToken);
+
+    Task<VodStreamInfo> GetVodInfoAsync(ConnectionInfo connectionInfo, int streamId, CancellationToken cancellationToken);
+
+    Task<List<StreamInfo>> GetVodStreamsByCategoryAsync(ConnectionInfo connectionInfo, int categoryId, CancellationToken cancellationToken);
+}
+--- END OF FILE: ./Jellyfin.Xtream/Client/IXtreamClient.cs ---
+
+--- START OF FILE: ./Jellyfin.Xtream/Client/XtreamClient.cs ---
+// Copyright (C) 2022  Kevin Jilissen
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Xtream.Client.Models;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+
+#pragma warning disable CS1591
+namespace Jellyfin.Xtream.Client;
+
+/// <summary>
+/// The Xtream API client implementation.
+/// </summary>
+/// <remarks>
+/// Initializes a new instance of the <see cref="XtreamClient"/> class.
+/// </remarks>
+/// <param name="client">The HTTP client used.</param>
+/// <param name="logger">Instance of the <see cref="ILogger"/> interface.</param>
+public class XtreamClient(HttpClient client, ILogger<XtreamClient> logger) : IDisposable, IXtreamClient
+{
+    private readonly JsonSerializerSettings _serializerSettings = new()
+    {
+        Error = NullableEventHandler(logger),
+    };
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="XtreamClient"/> class.
+    /// </summary>
+    /// <param name="logger">Instance of the <see cref="ILogger"/> interface.</param>
+    public XtreamClient(ILogger<XtreamClient> logger) : this(CreateDefaultClient(), logger)
+    {
+    }
+
+    private static HttpClient CreateDefaultClient()
+    {
+        HttpClient client = new HttpClient();
+
+        ProductHeaderValue header = new ProductHeaderValue("Jellyfin.Xtream", Assembly.GetExecutingAssembly().GetName().Version?.ToString());
+        ProductInfoHeaderValue userAgent = new ProductInfoHeaderValue(header);
+        client.DefaultRequestHeaders.UserAgent.Add(userAgent);
+
+        return client;
+    }
+
+    /// <summary>
+    /// Ignores error events if the target property is nullable.
+    /// </summary>
+    /// <param name="logger">Instance of the <see cref="ILogger"/> interface.</param>
+    /// <returns>An event handler using the given logger.</returns>
+    public static EventHandler<ErrorEventArgs> NullableEventHandler(ILogger<XtreamClient> logger)
+    {
+        return (object? sender, ErrorEventArgs args) =>
+        {
+            if (args.ErrorContext.OriginalObject?.GetType() is Type type && args.ErrorContext.Member is string jsonName)
+            {
+                PropertyInfo? property = type.GetProperties().FirstOrDefault((p) =>
+                {
+                    CustomAttributeData? attribute = p.CustomAttributes.FirstOrDefault(a => a.AttributeType == typeof(JsonPropertyAttribute));
+                    if (attribute == null)
+                    {
+                        return false;
+                    }
+
+                    if (attribute.ConstructorArguments.Count > 0)
+                    {
+                        // Attribute contains a `propertyName`.
+                        string? value = attribute.ConstructorArguments.First().Value as string;
+                        return jsonName.Equals(value, StringComparison.Ordinal);
+                    }
+                    else
+                    {
+                        // Attribute does not contain a `propertyName`, compare with the name of the property itself.
+                        return jsonName.Equals(p.Name, StringComparison.Ordinal);
+                    }
+                });
+
+                if (property != null && Nullable.GetUnderlyingType(property.PropertyType) != null)
+                {
+                    logger.LogDebug("Property `{0}` (`{1}` in JSON) is nullable, ignoring parsing error!", property.Name, jsonName);
+                    logger.LogDebug("Stack trace: {0}", new System.Diagnostics.StackTrace());
+                    args.ErrorContext.Handled = true;
+                }
+            }
+        };
+    }
+
+    private async Task<T> QueryApi<T>(ConnectionInfo connectionInfo, string urlPath, CancellationToken cancellationToken)
+    {
+        Uri uri = new Uri(connectionInfo.BaseUrl + urlPath);
+        string jsonContent = await client.GetStringAsync(uri, cancellationToken).ConfigureAwait(false);
+        return JsonConvert.DeserializeObject<T>(jsonContent, _serializerSettings)!;
+    }
+
+    public Task<PlayerApi> GetUserAndServerInfoAsync(ConnectionInfo connectionInfo, CancellationToken cancellationToken) =>
+        QueryApi<PlayerApi>(
+          connectionInfo,
+          $"/player_api.php?username={connectionInfo.UserName}&password={connectionInfo.Password}",
+          cancellationToken);
+
+    public Task<List<Series>> GetSeriesByCategoryAsync(ConnectionInfo connectionInfo, int categoryId, CancellationToken cancellationToken) =>
+         QueryApi<List<Series>>(
+           connectionInfo,
+           $"/player_api.php?username={connectionInfo.UserName}&password={connectionInfo.Password}&action=get_series&category_id={categoryId}",
+           cancellationToken);
+
+    public Task<SeriesStreamInfo> GetSeriesStreamsBySeriesAsync(ConnectionInfo connectionInfo, int seriesId, CancellationToken cancellationToken) =>
+         QueryApi<SeriesStreamInfo>(
+           connectionInfo,
+           $"/player_api.php?username={connectionInfo.UserName}&password={connectionInfo.Password}&action=get_series_info&series_id={seriesId}",
+           cancellationToken);
+
+    public Task<List<StreamInfo>> GetVodStreamsByCategoryAsync(ConnectionInfo connectionInfo, int categoryId, CancellationToken cancellationToken) =>
+         QueryApi<List<StreamInfo>>(
+           connectionInfo,
+           $"/player_api.php?username={connectionInfo.UserName}&password={connectionInfo.Password}&action=get_vod_streams&category_id={categoryId}",
+           cancellationToken);
+
+    public Task<VodStreamInfo> GetVodInfoAsync(ConnectionInfo connectionInfo, int streamId, CancellationToken cancellationToken) =>
+         QueryApi<VodStreamInfo>(
+           connectionInfo,
+           $"/player_api.php?username={connectionInfo.UserName}&password={connectionInfo.Password}&action=get_vod_info&vod_id={streamId}",
+           cancellationToken);
+
+    public Task<List<StreamInfo>> GetLiveStreamsAsync(ConnectionInfo connectionInfo, CancellationToken cancellationToken) =>
+         QueryApi<List<StreamInfo>>(
+           connectionInfo,
+           $"/player_api.php?username={connectionInfo.UserName}&password={connectionInfo.Password}&action=get_live_streams",
+           cancellationToken);
+
+    public Task<List<StreamInfo>> GetLiveStreamsByCategoryAsync(ConnectionInfo connectionInfo, int categoryId, CancellationToken cancellationToken) =>
+         QueryApi<List<StreamInfo>>(
+           connectionInfo,
+           $"/player_api.php?username={connectionInfo.UserName}&password={connectionInfo.Password}&action=get_live_streams&category_id={categoryId}",
+           cancellationToken);
+
+    public Task<List<Category>> GetSeriesCategoryAsync(ConnectionInfo connectionInfo, CancellationToken cancellationToken) =>
+         QueryApi<List<Category>>(
+           connectionInfo,
+           $"/player_api.php?username={connectionInfo.UserName}&password={connectionInfo.Password}&action=get_series_categories",
+           cancellationToken);
+
+    public Task<List<Category>> GetVodCategoryAsync(ConnectionInfo connectionInfo, CancellationToken cancellationToken) =>
+         QueryApi<List<Category>>(
+           connectionInfo,
+           $"/player_api.php?username={connectionInfo.UserName}&password={connectionInfo.Password}&action=get_vod_categories",
+           cancellationToken);
+
+    public Task<List<Category>> GetLiveCategoryAsync(ConnectionInfo connectionInfo, CancellationToken cancellationToken) =>
+         QueryApi<List<Category>>(
+           connectionInfo,
+           $"/player_api.php?username={connectionInfo.UserName}&password={connectionInfo.Password}&action=get_live_categories",
+           cancellationToken);
+
+    public Task<EpgListings> GetEpgInfoAsync(ConnectionInfo connectionInfo, int streamId, CancellationToken cancellationToken) =>
+         QueryApi<EpgListings>(
+           connectionInfo,
+           $"/player_api.php?username={connectionInfo.UserName}&password={connectionInfo.Password}&action=get_simple_data_table&stream_id={streamId}",
+           cancellationToken);
+
+    /// <summary>
+    /// Dispose the HTTP client.
+    /// </summary>
+    /// <param name="b">Unused.</param>
+    protected virtual void Dispose(bool b)
+    {
+        client?.Dispose();
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+}
+--- END OF FILE: ./Jellyfin.Xtream/Client/XtreamClient.cs ---
+
+--- START OF FILE: ./Jellyfin.Xtream/Client/Base64Converter.cs ---
+// Copyright (C) 2022  Kevin Jilissen
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System;
+using System.Text;
+using Newtonsoft.Json;
+
+namespace Jellyfin.Xtream.Client;
+
+/// <summary>
+/// Class Base64Converter converts strings from and to base64.
+/// </summary>
+public class Base64Converter : JsonConverter
+{
+    /// <inheritdoc />
+    public override bool CanConvert(Type objectType)
+    {
+        return objectType == typeof(string);
+    }
+
+    /// <inheritdoc />
+    public override object ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
+    {
+        if (reader.Value == null)
+        {
+            throw new ArgumentException("Value cannot be null.");
+        }
+
+        byte[] bytes = Convert.FromBase64String((string)reader.Value);
+        return Encoding.UTF8.GetString(bytes);
+    }
+
+    /// <inheritdoc />
+    public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
+    {
+        if (value == null)
+        {
+            throw new ArgumentException("Value cannot be null.");
+        }
+
+        byte[] bytes = Encoding.UTF8.GetBytes((string)value);
+        writer.WriteValue(Convert.ToBase64String(bytes));
+    }
+}
+--- END OF FILE: ./Jellyfin.Xtream/Client/Base64Converter.cs ---
+
+--- START OF FILE: ./Jellyfin.Xtream/Client/OnlyObjectConverter.cs ---
+// Copyright (C) 2022  Kevin Jilissen
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Jellyfin.Xtream.Client;
+
+/// <summary>
+/// Class OnlyObjectConverter converts only object tokens.
+/// </summary>
+/// <typeparam name="T">The object which should be converted.</typeparam>
+public class OnlyObjectConverter<T> : JsonConverter
+{
+    /// <inheritdoc/>
+    public override bool CanConvert(Type objectType)
+    {
+        return objectType == typeof(T);
+    }
+
+    /// <inheritdoc/>
+    public override object? ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
+    {
+        JToken token = JToken.Load(reader);
+        if (token.Type == JTokenType.Object)
+        {
+            return token.ToObject<T>();
+        }
+
+        return null;
+    }
+
+    /// <inheritdoc/>
+    public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
+    {
+        serializer.Serialize(writer, value);
+    }
+}
+--- END OF FILE: ./Jellyfin.Xtream/Client/OnlyObjectConverter.cs ---
+
+--- START OF FILE: ./Jellyfin.Xtream/Client/SingularToListConverter.cs ---
+// Copyright (C) 2022  Kevin Jilissen
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Jellyfin.Xtream.Client;
+
+/// <summary>
+/// Class SingularToListConverter converts singular tokens to lists.
+/// </summary>
+/// <typeparam name="T">The object which should be converted.</typeparam>
+public class SingularToListConverter<T> : JsonConverter
+{
+    /// <inheritdoc/>
+    public override bool CanConvert(Type objectType)
+    {
+        return objectType == typeof(T);
+    }
+
+    /// <inheritdoc/>
+    public override ICollection<T>? ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
+    {
+        switch (reader.TokenType)
+        {
+            case JsonToken.StartObject:
+                T? result = serializer.Deserialize<T>(reader);
+                if (result is null)
+                {
+                    return null;
+                }
+
+                return [result];
+            case JsonToken.StartArray:
+                return serializer.Deserialize<List<T>>(reader);
+            case JsonToken.String:
+                if (typeof(T) == typeof(string))
+                {
+                    goto case JsonToken.StartObject;
+                }
+
+                goto default;
+            case JsonToken.Null:
+                return [];
+            default:
+                throw new JsonReaderException("The JsonReader points to an unexpected point.");
+        }
+    }
+
+    /// <inheritdoc/>
+    public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
+    {
+        if (value is T typedValue)
+        {
+            value = new List<T> { typedValue };
+        }
+
+        serializer.Serialize(writer, value);
+    }
+}
+--- END OF FILE: ./Jellyfin.Xtream/Client/SingularToListConverter.cs ---
+
+--- START OF FILE: ./Jellyfin.Xtream/Client/Models/Season.cs ---
+// Copyright (C) 2022  Kevin Jilissen
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System;
+using Newtonsoft.Json;
+
+#pragma warning disable CS1591
+namespace Jellyfin.Xtream.Client.Models;
+
+public class Season
+{
+    [JsonProperty("air_date")]
+    public DateTime? AirDate { get; set; }
+
+    [JsonProperty("episode_count")]
+    public int EpisodeCount { get; set; }
+
+    [JsonProperty("id")]
+    public int SeasonId { get; set; }
+
+    [JsonProperty("name")]
+    public string Name { get; set; } = string.Empty;
+
+    [JsonProperty("overview")]
+    public string Overview { get; set; } = string.Empty;
+
+    [JsonProperty("season_number")]
+    public int Cast { get; set; }
+
+    [JsonProperty("cover")]
+    public string Cover { get; set; } = string.Empty;
+
+    [JsonProperty("cover_big")]
+    public string CoverBig { get; set; } = string.Empty;
+}
+--- END OF FILE: ./Jellyfin.Xtream/Client/Models/Season.cs ---
+
+--- START OF FILE: ./Jellyfin.Xtream/Client/Models/SeriesInfo.cs ---
+// Copyright (C) 2022  Kevin Jilissen
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+#pragma warning disable CS1591
+namespace Jellyfin.Xtream.Client.Models;
+
+public class SeriesInfo
+{
+    [JsonProperty("name")]
+    public string Name { get; set; } = string.Empty;
+
+    [JsonProperty("cover")]
+    public string Cover { get; set; } = string.Empty;
+
+    [JsonProperty("plot")]
+    public string Plot { get; set; } = string.Empty;
+
+    [JsonProperty("cast")]
+    public string Cast { get; set; } = string.Empty;
+
+    [JsonProperty("director")]
+    public string Director { get; set; } = string.Empty;
+
+    [JsonProperty("genre")]
+    public string Genre { get; set; } = string.Empty;
+
+    // [JsonProperty("releaseDate")]
+    // public long ReleaseDate { get; set; }
+
+    [JsonConverter(typeof(UnixDateTimeConverter))]
+    [JsonProperty("last_modified")]
+    public DateTime LastModified { get; set; }
+
+    [JsonProperty("rating")]
+    public decimal Rating { get; set; }
+
+    [JsonProperty("rating_5based")]
+    public decimal Rating5Based { get; set; }
+
+    [JsonProperty("backdrop_path")]
+    #pragma warning disable CA2227
+    public ICollection<string> BackdropPaths { get; set; } = new List<string>();
+    #pragma warning restore CA2227
+
+    [JsonProperty("youtube_trailer")]
+    public string YoutubeTrailer { get; set; } = string.Empty;
+
+    [JsonProperty("episode_run_time")]
+    public int EpisodeRunTime { get; set; }
+
+    [JsonProperty("category_id")]
+    public int CategoryId { get; set; }
+}
+--- END OF FILE: ./Jellyfin.Xtream/Client/Models/SeriesInfo.cs ---
+
+--- START OF FILE: ./Jellyfin.Xtream/Client/Models/VodStreamInfo.cs ---
+// Copyright (C) 2022  Kevin Jilissen
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using Newtonsoft.Json;
+
+#pragma warning disable CS1591
+namespace Jellyfin.Xtream.Client.Models;
+
+public class VodStreamInfo
+{
+    [JsonProperty("info")]
+    [JsonConverter(typeof(OnlyObjectConverter<VodInfo>))]
+    public VodInfo? Info { get; set; }
+
+    [JsonProperty("movie_data")]
+    [JsonConverter(typeof(OnlyObjectConverter<StreamInfo>))]
+    public StreamInfo? MovieData { get; set; }
+}
+--- END OF FILE: ./Jellyfin.Xtream/Client/Models/VodStreamInfo.cs ---
+
+--- START OF FILE: ./Jellyfin.Xtream/Client/Models/EpisodeInfo.cs ---
+// Copyright (C) 2022  Kevin Jilissen
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System;
+using Newtonsoft.Json;
+
+#pragma warning disable CS1591
+namespace Jellyfin.Xtream.Client.Models;
+
+public class EpisodeInfo
+{
+    [JsonProperty("movie_image")]
+    public string? MovieImage { get; set; }
+
+    [JsonProperty("plot")]
+    public string? Plot { get; set; }
+
+    [JsonProperty("releasedate")]
+    public DateTime? ReleaseDate { get; set; }
+
+    [JsonProperty("rating")]
+    public decimal? Rating { get; set; }
+
+    [JsonProperty("duration_secs")]
+    public int? DurationSecs { get; set; }
+
+    [JsonProperty("bitrate")]
+    public int? Bitrate { get; set; }
+
+    [JsonProperty("video")]
+    [JsonConverter(typeof(OnlyObjectConverter<VideoInfo>))]
+    public VideoInfo? Video { get; set; }
+
+    [JsonProperty("audio")]
+    [JsonConverter(typeof(OnlyObjectConverter<AudioInfo>))]
+    public AudioInfo? Audio { get; set; }
+}
+--- END OF FILE: ./Jellyfin.Xtream/Client/Models/EpisodeInfo.cs ---
+
+--- START OF FILE: ./Jellyfin.Xtream/Client/Models/ServerInfo.cs ---
+﻿// Copyright (C) 2022  Kevin Jilissen
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+#pragma warning disable CS1591
+namespace Jellyfin.Xtream.Client.Models;
+
+public class ServerInfo
+{
+    [JsonProperty("url")]
+    public string Url { get; set; } = string.Empty;
+
+    [JsonProperty("port")]
+    public string Port { get; set; } = string.Empty;
+
+    [JsonProperty("rtmp_port")]
+    public string RtmpPort { get; set; } = string.Empty;
+
+    [JsonProperty("timezone")]
+    public string Timezone { get; set; } = string.Empty;
+
+    [JsonConverter(typeof(UnixDateTimeConverter))]
+    [JsonProperty("timestamp_now")]
+    public DateTime TimeNow { get; set; }
+}
+--- END OF FILE: ./Jellyfin.Xtream/Client/Models/ServerInfo.cs ---
+
+--- START OF FILE: ./Jellyfin.Xtream/Client/Models/EpgInfo.cs ---
+// Copyright (C) 2022  Kevin Jilissen
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+#pragma warning disable CS1591
+namespace Jellyfin.Xtream.Client.Models;
+
+public class EpgInfo
+{
+    [JsonProperty("id")]
+    public int Id { get; set; }
+
+    [JsonProperty("epg_id")]
+    public int EpgId { get; set; }
+
+    [JsonConverter(typeof(Base64Converter))]
+    [JsonProperty("title")]
+    public string Title { get; set; } = string.Empty;
+
+    [JsonProperty("lang")]
+    public string Language { get; set; } = string.Empty;
+
+    [JsonConverter(typeof(UnixDateTimeConverter))]
+    [JsonProperty("start_timestamp")]
+    public DateTime Start { get; set; }
+
+    [JsonProperty("start")]
+    public DateTime StartLocalTime { get; set; }
+
+    [JsonConverter(typeof(UnixDateTimeConverter))]
+    [JsonProperty("stop_timestamp")]
+    public DateTime End { get; set; }
+
+    [JsonConverter(typeof(Base64Converter))]
+    [JsonProperty("description")]
+    public string Description { get; set; } = string.Empty;
+
+    [JsonProperty("channel_id")]
+    public string ChannelId { get; set; } = string.Empty;
+
+    [JsonProperty("now_playing")]
+    public bool NowPlaying { get; set; }
+
+    [JsonProperty("has_archive")]
+    public bool HasArchive { get; set; }
+}
+--- END OF FILE: ./Jellyfin.Xtream/Client/Models/EpgInfo.cs ---
+
+--- START OF FILE: ./Jellyfin.Xtream/Client/Models/StreamInfo.cs ---
+﻿// Copyright (C) 2022  Kevin Jilissen
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using Newtonsoft.Json;
+
+#pragma warning disable CS1591
+namespace Jellyfin.Xtream.Client.Models;
+
+public class StreamInfo
+{
+    [JsonProperty("num")]
+    public int Num { get; set; }
+
+    [JsonProperty("name")]
+    public string Name { get; set; } = string.Empty;
+
+    [JsonProperty("stream_type")]
+    public string StreamType { get; set; } = string.Empty;
+
+    [JsonProperty("stream_id")]
+    public int StreamId { get; set; }
+
+    [JsonProperty("stream_icon")]
+    public string StreamIcon { get; set; } = string.Empty;
+
+    [JsonProperty("epg_channel_id")]
+    public string EpgChannelId { get; set; } = string.Empty;
+
+    [JsonProperty("added")]
+    public string Added { get; set; } = string.Empty;
+
+    [JsonProperty("category_id")]
+    public int? CategoryId { get; set; }
+
+    [JsonProperty("container_extension")]
+    public string ContainerExtension { get; set; } = string.Empty;
+
+    [JsonProperty("custom_sid")]
+    public string CustomSid { get; set; } = string.Empty;
+
+    [JsonProperty("tv_archive")]
+    public bool TvArchive { get; set; }
+
+    [JsonProperty("direct_source")]
+    public string DirectSource { get; set; } = string.Empty;
+
+    [JsonProperty("tv_archive_duration")]
+    public int TvArchiveDuration { get; set; }
+}
+--- END OF FILE: ./Jellyfin.Xtream/Client/Models/StreamInfo.cs ---
+
+--- START OF FILE: ./Jellyfin.Xtream/Client/Models/UserInfo.cs ---
+﻿// Copyright (C) 2022  Kevin Jilissen
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+#pragma warning disable CS1591
+namespace Jellyfin.Xtream.Client.Models;
+
+public class UserInfo
+{
+    [JsonProperty("username")]
+    public string Username { get; set; } = string.Empty;
+
+    [JsonProperty("password")]
+    public string Password { get; set; } = string.Empty;
+
+    [JsonProperty("auth")]
+    public int Auth { get; set; }
+
+    [JsonProperty("status")]
+    public string Status { get; set; } = string.Empty;
+
+    [JsonConverter(typeof(UnixDateTimeConverter))]
+    [JsonProperty("exp_date")]
+    public DateTime? ExpDate { get; set; }
+
+    [JsonConverter(typeof(StringBoolConverter))]
+    [JsonProperty("is_trial")]
+    public bool? IsTrial { get; set; }
+
+    [JsonProperty("active_cons")]
+    public int ActiveCons { get; set; }
+
+    [JsonConverter(typeof(UnixDateTimeConverter))]
+    [JsonProperty("created_at")]
+    public DateTime CreatedAt { get; set; }
+
+    [JsonProperty("max_connections")]
+    public int MaxConnections { get; set; }
+
+    #pragma warning disable CA2227
+    [JsonProperty("allowed_output_formats")]
+    public ICollection<string> AllowedOutputFormats { get; set; } = new List<string>();
+    #pragma warning restore CA2227
+}
+--- END OF FILE: ./Jellyfin.Xtream/Client/Models/UserInfo.cs ---
+
+--- START OF FILE: ./Jellyfin.Xtream/Client/Models/EpgListings.cs ---
+// Copyright (C) 2022  Kevin Jilissen
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+#pragma warning disable CS1591
+#pragma warning disable CA2227
+namespace Jellyfin.Xtream.Client.Models;
+
+public class EpgListings
+{
+    [JsonProperty("epg_listings")]
+    public ICollection<EpgInfo> Listings { get; set; } = new List<EpgInfo>();
+}
+#pragma warning restore CA2227
+#pragma warning restore CS1591
+--- END OF FILE: ./Jellyfin.Xtream/Client/Models/EpgListings.cs ---
+
+--- START OF FILE: ./Jellyfin.Xtream/Client/Models/Episode.cs ---
+// Copyright (C) 2022  Kevin Jilissen
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+#pragma warning disable CS1591
+namespace Jellyfin.Xtream.Client.Models;
+
+public class Episode
+{
+    [JsonProperty("id")]
+    public int EpisodeId { get; set; }
+
+    [JsonProperty("episode_num")]
+    public int EpisodeNum { get; set; }
+
+    [JsonProperty("title")]
+    public string Title { get; set; } = string.Empty;
+
+    [JsonProperty("container_extension")]
+    public string ContainerExtension { get; set; } = string.Empty;
+
+    [JsonConverter(typeof(OnlyObjectConverter<EpisodeInfo>))]
+    [JsonProperty("info")]
+    public EpisodeInfo? Info { get; set; } = new EpisodeInfo();
+
+    [JsonProperty("custom_sid")]
+    public string CustomSid { get; set; } = string.Empty;
+
+    [JsonConverter(typeof(UnixDateTimeConverter))]
+    [JsonProperty("added")]
+    public DateTime? Added { get; set; }
+
+    [JsonProperty("season")]
+    public int Season { get; set; }
+
+    [JsonProperty("direct_source")]
+    public string DirectSource { get; set; } = string.Empty;
+}
+--- END OF FILE: ./Jellyfin.Xtream/Client/Models/Episode.cs ---
+
+--- START OF FILE: ./Jellyfin.Xtream/Client/Models/VideoInfo.cs ---
+// Copyright (C) 2022  Kevin Jilissen
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using Newtonsoft.Json;
+
+#pragma warning disable CS1591
+namespace Jellyfin.Xtream.Client.Models;
+
+public class VideoInfo
+{
+    [JsonProperty("index")]
+    public int Index { get; set; }
+
+    [JsonProperty("codec_name")]
+    public string CodecName { get; set; } = string.Empty;
+
+    [JsonProperty("profile")]
+    public string Profile { get; set; } = string.Empty;
+
+    [JsonProperty("width")]
+    public int Width { get; set; }
+
+    [JsonProperty("height")]
+    public int Height { get; set; }
+
+    [JsonProperty("display_aspect_ratio")]
+    public string AspectRatio { get; set; } = string.Empty;
+
+    [JsonProperty("pix_fmt")]
+    public string PixelFormat { get; set; } = string.Empty;
+
+    [JsonProperty("level")]
+    public int Level { get; set; }
+
+    [JsonProperty("color_range")]
+    public string ColorRange { get; set; } = string.Empty;
+
+    [JsonProperty("color_space")]
+    public string ColorSpace { get; set; } = string.Empty;
+
+    [JsonProperty("color_transfer")]
+    public string ColorTransfer { get; set; } = string.Empty;
+
+    [JsonProperty("color_primaries")]
+    public string ColorPrimaries { get; set; } = string.Empty;
+
+    [JsonProperty("is_avc")]
+    public bool IsAVC { get; set; }
+
+    [JsonProperty("bits_per_raw_sample")]
+    public int BitsPerRawSample { get; set; }
+}
+--- END OF FILE: ./Jellyfin.Xtream/Client/Models/VideoInfo.cs ---
+
+--- START OF FILE: ./Jellyfin.Xtream/Client/Models/AudioInfo.cs ---
+// Copyright (C) 2022  Kevin Jilissen
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using Newtonsoft.Json;
+
+#pragma warning disable CS1591
+namespace Jellyfin.Xtream.Client.Models;
+
+public class AudioInfo
+{
+    [JsonProperty("index")]
+    public int Index { get; set; }
+
+    [JsonProperty("codec_name")]
+    public string CodecName { get; set; } = string.Empty;
+
+    [JsonProperty("profile")]
+    public string Profile { get; set; } = string.Empty;
+
+    [JsonProperty("sample_fmt")]
+    public string SampleFormat { get; set; } = string.Empty;
+
+    [JsonProperty("sample_rate")]
+    public int SampleRate { get; set; }
+
+    [JsonProperty("channels")]
+    public int Channels { get; set; }
+
+    [JsonProperty("channel_layout")]
+    public string ChannelLayout { get; set; } = string.Empty;
+
+    [JsonProperty("bit_rate")]
+    public int Bitrate { get; set; }
+}
+--- END OF FILE: ./Jellyfin.Xtream/Client/Models/AudioInfo.cs ---
+
+--- START OF FILE: ./Jellyfin.Xtream/Client/Models/PlayerApi.cs ---
+﻿// Copyright (C) 2022  Kevin Jilissen
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#pragma warning disable CS1591
+using Newtonsoft.Json;
+
+namespace Jellyfin.Xtream.Client.Models;
+
+public class PlayerApi
+{
+    [JsonProperty("user_info")]
+    public UserInfo UserInfo { get; set; } = new UserInfo();
+
+    [JsonProperty("server_info")]
+    public ServerInfo ServerInfo { get; set; } = new ServerInfo();
+}
+--- END OF FILE: ./Jellyfin.Xtream/Client/Models/PlayerApi.cs ---
+
+--- START OF FILE: ./Jellyfin.Xtream/Client/Models/Category.cs ---
+﻿// Copyright (C) 2022  Kevin Jilissen
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using Newtonsoft.Json;
+
+#pragma warning disable CS1591
+namespace Jellyfin.Xtream.Client.Models;
+
+public class Category
+{
+    [JsonProperty("category_id")]
+    public int CategoryId { get; set; }
+
+    [JsonProperty("category_name")]
+    public string CategoryName { get; set; } = string.Empty;
+
+    [JsonProperty("parent_id")]
+    public int ParentId { get; set; }
+}
+--- END OF FILE: ./Jellyfin.Xtream/Client/Models/Category.cs ---
+
+--- START OF FILE: ./Jellyfin.Xtream/Client/Models/SeriesStreamInfo.cs ---
+// Copyright (C) 2022  Kevin Jilissen
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+#pragma warning disable CS1591
+namespace Jellyfin.Xtream.Client.Models;
+
+public class SeriesStreamInfo
+{
+    [JsonProperty("seasons")]
+#pragma warning disable CA2227
+    public ICollection<Season> Seasons { get; set; } = new List<Season>();
+#pragma warning restore CA2227
+
+    [JsonProperty("info")]
+    public SeriesInfo Info { get; set; } = new SeriesInfo();
+
+    [JsonProperty("episodes")]
+#pragma warning disable CA2227
+    public Dictionary<int, ICollection<Episode>> Episodes { get; set; } = new Dictionary<int, ICollection<Episode>>();
+#pragma warning restore CA2227
+}
+--- END OF FILE: ./Jellyfin.Xtream/Client/Models/SeriesStreamInfo.cs ---
+
+--- START OF FILE: ./Jellyfin.Xtream/Client/Models/Series.cs ---
+// Copyright (C) 2022  Kevin Jilissen
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+#pragma warning disable CS1591
+namespace Jellyfin.Xtream.Client.Models;
+
+public class Series
+{
+    [JsonProperty("num")]
+    public int Num { get; set; }
+
+    [JsonProperty("name")]
+    public string Name { get; set; } = string.Empty;
+
+    [JsonProperty("series_id")]
+    public int SeriesId { get; set; }
+
+    [JsonProperty("cover")]
+    public string Cover { get; set; } = string.Empty;
+
+    [JsonProperty("plot")]
+    public string Plot { get; set; } = string.Empty;
+
+    [JsonProperty("cast")]
+    public string Cast { get; set; } = string.Empty;
+
+    [JsonProperty("director")]
+    public string Director { get; set; } = string.Empty;
+
+    [JsonProperty("genre")]
+    public string Genre { get; set; } = string.Empty;
+
+    // [JsonProperty("releaseDate")]
+    // public long ReleaseDate { get; set; }
+
+    [JsonConverter(typeof(UnixDateTimeConverter))]
+    [JsonProperty("last_modified")]
+    public DateTime LastModified { get; set; }
+
+    [JsonProperty("rating")]
+    public decimal Rating { get; set; }
+
+    [JsonProperty("rating_5based")]
+    public decimal Rating5Based { get; set; }
+
+    [JsonConverter(typeof(SingularToListConverter<string>))]
+    [JsonProperty("backdrop_path")]
+#pragma warning disable CA2227
+    public ICollection<string> BackdropPaths { get; set; } = new List<string>();
+#pragma warning restore CA2227
+
+    [JsonProperty("youtube_trailer")]
+    public string YoutubeTrailer { get; set; } = string.Empty;
+
+    [JsonProperty("episode_run_time")]
+    public int EpisodeRunTime { get; set; }
+
+    [JsonProperty("category_id")]
+    public int CategoryId { get; set; }
+}
+--- END OF FILE: ./Jellyfin.Xtream/Client/Models/Series.cs ---
+
+--- START OF FILE: ./Jellyfin.Xtream/Client/Models/VodInfo.cs ---
+// Copyright (C) 2022  Kevin Jilissen
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System;
+using Newtonsoft.Json;
+
+#pragma warning disable CS1591
+namespace Jellyfin.Xtream.Client.Models;
+
+public class VodInfo
+{
+    [JsonProperty("movie_image")]
+    public string? MovieImage { get; set; }
+
+    [JsonProperty("genre")]
+    public string? Genre { get; set; }
+
+    [JsonProperty("plot")]
+    public string? Plot { get; set; }
+
+    [JsonProperty("director")]
+    public string? Director { get; set; }
+
+    [JsonProperty("rating")]
+    public decimal? Rating { get; set; }
+
+    [JsonProperty("releasedate")]
+    public DateTime? ReleaseDate { get; set; }
+
+    [JsonProperty("duration_secs")]
+    public int? DurationSecs { get; set; }
+
+    [JsonProperty("tmdb_id")]
+    public int? TmdbId { get; set; }
+
+    [JsonProperty("bitrate")]
+    public int Bitrate { get; set; }
+
+    [JsonProperty("video")]
+    [JsonConverter(typeof(OnlyObjectConverter<VideoInfo>))]
+    public VideoInfo? Video { get; set; }
+
+    [JsonProperty("audio")]
+    [JsonConverter(typeof(OnlyObjectConverter<AudioInfo>))]
+    public AudioInfo? Audio { get; set; }
+}
+--- END OF FILE: ./Jellyfin.Xtream/Client/Models/VodInfo.cs ---
+
+--- START OF FILE: ./Jellyfin.Xtream/Api/XtreamController.cs ---
+// Copyright (C) 2022  Kevin Jilissen
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Mime;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Xtream.Api.Models;
+using Jellyfin.Xtream.Client;
+using Jellyfin.Xtream.Client.Models;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Xtream.Api;
+
+/// <summary>
+/// The Jellyfin Xtream configuration API.
+/// </summary>
+[ApiController]
+[Route("[controller]")]
+[Produces(MediaTypeNames.Application.Json)]
+public class XtreamController(IXtreamClient xtreamClient) : ControllerBase
+{
+    private static CategoryResponse CreateCategoryResponse(Category category) =>
+        new()
+        {
+            Id = category.CategoryId,
+            Name = category.CategoryName,
+        };
+
+    private static ItemResponse CreateItemResponse(StreamInfo stream) =>
+        new()
+        {
+            Id = stream.StreamId,
+            Name = stream.Name,
+            HasCatchup = stream.TvArchive,
+            CatchupDuration = stream.TvArchiveDuration,
+        };
+
+    private static ItemResponse CreateItemResponse(Series series) =>
+        new()
+        {
+            Id = series.SeriesId,
+            Name = series.Name,
+            HasCatchup = false,
+            CatchupDuration = 0,
+        };
+
+    private static ChannelResponse CreateChannelResponse(StreamInfo stream) =>
+        new()
+        {
+            Id = stream.StreamId,
+            LogoUrl = stream.StreamIcon,
+            Name = stream.Name,
+            Number = stream.Num,
+        };
+
+    /// <summary>
+    /// Test the configured provider.
+    /// </summary>
+    /// <param name="cancellationToken">The cancellation token for cancelling requests.</param>
+    /// <returns>An enumerable containing the categories.</returns>
+    [Authorize(Policy = "RequiresElevation")]
+    [HttpGet("TestProvider")]
+    public async Task<ActionResult<ProviderTestResponse>> TestProvider(CancellationToken cancellationToken)
+    {
+        Plugin plugin = Plugin.Instance;
+        PlayerApi info = await xtreamClient.GetUserAndServerInfoAsync(plugin.Creds, cancellationToken).ConfigureAwait(false);
+        return Ok(new ProviderTestResponse()
+        {
+            ActiveConnections = info.UserInfo.ActiveCons,
+            ExpiryDate = info.UserInfo.ExpDate,
+            MaxConnections = info.UserInfo.MaxConnections,
+            ServerTime = info.ServerInfo.TimeNow,
+            ServerTimezone = info.ServerInfo.Timezone,
+            Status = info.UserInfo.Status,
+            SupportsMpegTs = info.UserInfo.AllowedOutputFormats.Contains("ts"),
+        });
+    }
+
+    /// <summary>
+    /// Get all Live TV categories.
+    /// </summary>
+    /// <param name="cancellationToken">The cancellation token for cancelling requests.</param>
+    /// <returns>An enumerable containing the categories.</returns>
+    [Authorize(Policy = "RequiresElevation")]
+    [HttpGet("LiveCategories")]
+    public async Task<ActionResult<IEnumerable<CategoryResponse>>> GetLiveCategories(CancellationToken cancellationToken)
+    {
+        Plugin plugin = Plugin.Instance;
+        List<Category> categories = await xtreamClient.GetLiveCategoryAsync(plugin.Creds, cancellationToken).ConfigureAwait(false);
+        return Ok(categories.Select(CreateCategoryResponse));
+    }
+
+    /// <summary>
+    /// Get all Live TV streams for the given category.
+    /// </summary>
+    /// <param name="categoryId">The category for which to fetch the streams.</param>
+    /// <param name="cancellationToken">The cancellation token for cancelling requests.</param>
+    /// <returns>An enumerable containing the streams.</returns>
+    [Authorize(Policy = "RequiresElevation")]
+    [HttpGet("LiveCategories/{categoryId}")]
+    public async Task<ActionResult<IEnumerable<StreamInfo>>> GetLiveStreams(int categoryId, CancellationToken cancellationToken)
+    {
+        Plugin plugin = Plugin.Instance;
+        List<StreamInfo> streams = await xtreamClient.GetLiveStreamsByCategoryAsync(
+          plugin.Creds,
+          categoryId,
+          cancellationToken).ConfigureAwait(false);
+        return Ok(streams.Select(CreateItemResponse));
+    }
+
+    /// <summary>
+    /// Get all VOD categories.
+    /// </summary>
+    /// <param name="cancellationToken">The cancellation token for cancelling requests.</param>
+    /// <returns>An enumerable containing the categories.</returns>
+    [Authorize(Policy = "RequiresElevation")]
+    [HttpGet("VodCategories")]
+    public async Task<ActionResult<IEnumerable<CategoryResponse>>> GetVodCategories(CancellationToken cancellationToken)
+    {
+        Plugin plugin = Plugin.Instance;
+        List<Category> categories = await xtreamClient.GetVodCategoryAsync(plugin.Creds, cancellationToken).ConfigureAwait(false);
+        return Ok(categories.Select(CreateCategoryResponse));
+    }
+
+    /// <summary>
+    /// Get all VOD streams for the given category.
+    /// </summary>
+    /// <param name="categoryId">The category for which to fetch the streams.</param>
+    /// <param name="cancellationToken">The cancellation token for cancelling requests.</param>
+    /// <returns>An enumerable containing the streams.</returns>
+    [Authorize(Policy = "RequiresElevation")]
+    [HttpGet("VodCategories/{categoryId}")]
+    public async Task<ActionResult<IEnumerable<StreamInfo>>> GetVodStreams(int categoryId, CancellationToken cancellationToken)
+    {
+        Plugin plugin = Plugin.Instance;
+        List<StreamInfo> streams = await xtreamClient.GetVodStreamsByCategoryAsync(
+          plugin.Creds,
+          categoryId,
+          cancellationToken).ConfigureAwait(false);
+        return Ok(streams.Select(CreateItemResponse));
+    }
+
+    /// <summary>
+    /// Get all Series categories.
+    /// </summary>
+    /// <param name="cancellationToken">The cancellation token for cancelling requests.</param>
+    /// <returns>An enumerable containing the categories.</returns>
+    [Authorize(Policy = "RequiresElevation")]
+    [HttpGet("SeriesCategories")]
+    public async Task<ActionResult<IEnumerable<CategoryResponse>>> GetSeriesCategories(CancellationToken cancellationToken)
+    {
+        Plugin plugin = Plugin.Instance;
+        List<Category> categories = await xtreamClient.GetSeriesCategoryAsync(plugin.Creds, cancellationToken).ConfigureAwait(false);
+        return Ok(categories.Select(CreateCategoryResponse));
+    }
+
+    /// <summary>
+    /// Get all Series streams for the given category.
+    /// </summary>
+    /// <param name="categoryId">The category for which to fetch the streams.</param>
+    /// <param name="cancellationToken">The cancellation token for cancelling requests.</param>
+    /// <returns>An enumerable containing the streams.</returns>
+    [Authorize(Policy = "RequiresElevation")]
+    [HttpGet("SeriesCategories/{categoryId}")]
+    public async Task<ActionResult<IEnumerable<StreamInfo>>> GetSeriesStreams(int categoryId, CancellationToken cancellationToken)
+    {
+        Plugin plugin = Plugin.Instance;
+        List<Series> series = await xtreamClient.GetSeriesByCategoryAsync(
+          plugin.Creds,
+          categoryId,
+          cancellationToken).ConfigureAwait(false);
+        return Ok(series.Select(CreateItemResponse));
+    }
+
+    /// <summary>
+    /// Get all configured TV channels.
+    /// </summary>
+    /// <param name="cancellationToken">The cancellation token for cancelling requests.</param>
+    /// <returns>An enumerable containing the streams.</returns>
+    [Authorize(Policy = "RequiresElevation")]
+    [HttpGet("LiveTv")]
+    public async Task<ActionResult<IEnumerable<StreamInfo>>> GetLiveTvChannels(CancellationToken cancellationToken)
+    {
+        IEnumerable<StreamInfo> streams = await Plugin.Instance.StreamService.GetLiveStreams(cancellationToken).ConfigureAwait(false);
+        var channels = streams.Select(CreateChannelResponse).ToList();
+        return Ok(channels);
+    }
+}
+--- END OF FILE: ./Jellyfin.Xtream/Api/XtreamController.cs ---
+
+--- START OF FILE: ./Jellyfin.Xtream/Api/Models/ProviderTestResponse.cs ---
+// Copyright (C) 2022  Kevin Jilissen
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System;
+
+namespace Jellyfin.Xtream.Api.Models;
+
+/// <summary>
+/// A response model for Xtream provider tests.
+/// </summary>
+public class ProviderTestResponse
+{
+    /// <summary>
+    /// Gets or sets the status of provider.
+    /// </summary>
+    public string Status { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the account expiry date.
+    /// </summary>
+    public DateTime? ExpiryDate { get; set; }
+
+    /// <summary>
+    /// Gets or sets the current simultaneous connections to the provider.
+    /// </summary>
+    public int ActiveConnections { get; set; }
+
+    /// <summary>
+    /// Gets or sets the maximum simultaneous connections supported by the provider.
+    /// </summary>
+    public int MaxConnections { get; set; }
+
+    /// <summary>
+    /// Gets or sets the server time.
+    /// </summary>
+    public DateTime ServerTime { get; set; }
+
+    /// <summary>
+    /// Gets or sets the server time zone.
+    /// </summary>
+    public string ServerTimezone { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether or not MPEG-TS is supported by the provider.
+    /// </summary>
+    public bool SupportsMpegTs { get; set; }
+}
+--- END OF FILE: ./Jellyfin.Xtream/Api/Models/ProviderTestResponse.cs ---
+
+--- START OF FILE: ./Jellyfin.Xtream/Api/Models/ChannelResponse.cs ---
+// Copyright (C) 2022  Kevin Jilissen
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+namespace Jellyfin.Xtream.Api.Models;
+
+/// <summary>
+/// Override configuration for a Live TV channel.
+/// </summary>
+public class ChannelResponse
+{
+    /// <summary>
+    /// Gets or sets the Xtream API id of the TV channel.
+    /// </summary>
+    public int Id { get; set; }
+
+    /// <summary>
+    /// Gets or sets the TV channel number.
+    /// </summary>
+    public int Number { get; set; }
+
+    /// <summary>
+    /// Gets or sets the TV channel name.
+    /// </summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the url of the channel logo.
+    /// </summary>
+    public string LogoUrl { get; set; } = string.Empty;
+}
+--- END OF FILE: ./Jellyfin.Xtream/Api/Models/ChannelResponse.cs ---
+
+--- START OF FILE: ./Jellyfin.Xtream/Api/Models/CategoryResponse.cs ---
+// Copyright (C) 2022  Kevin Jilissen
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+namespace Jellyfin.Xtream.Api.Models;
+
+/// <summary>
+/// A response model for Xtream categories.
+/// </summary>
+public class CategoryResponse
+{
+    /// <summary>
+    /// Gets or sets the Xtream API id of the category.
+    /// </summary>
+    public int Id { get; set; }
+
+    /// <summary>
+    /// Gets or sets the name of the category.
+    /// </summary>
+    public string Name { get; set; } = string.Empty;
+}
+--- END OF FILE: ./Jellyfin.Xtream/Api/Models/CategoryResponse.cs ---
+
+--- START OF FILE: ./Jellyfin.Xtream/Api/Models/ItemResponse.cs ---
+// Copyright (C) 2022  Kevin Jilissen
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+namespace Jellyfin.Xtream.Api.Models;
+
+/// <summary>
+/// A response model for items inside an Xtream category.
+/// </summary>
+public class ItemResponse
+{
+    /// <summary>
+    /// Gets or sets the Xtream API id of the item.
+    /// </summary>
+    public int Id { get; set; }
+
+    /// <summary>
+    /// Gets or sets the name of the item.
+    /// </summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether or not catch-up is supported by the item.
+    /// </summary>
+    public bool HasCatchup { get; set; }
+
+    /// <summary>
+    /// Gets or sets the catch-up duration of the item in days.
+    /// </summary>
+    public int CatchupDuration { get; set; }
+}
+--- END OF FILE: ./Jellyfin.Xtream/Api/Models/ItemResponse.cs ---
+
+--- START OF FILE: ./Jellyfin.Xtream/Plugin.cs ---
+// Copyright (C) 2022  Kevin Jilissen
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Reflection;
+using Jellyfin.Xtream.Client;
+using Jellyfin.Xtream.Configuration;
+using Jellyfin.Xtream.Service;
+using MediaBrowser.Common.Configuration;
+using MediaBrowser.Common.Plugins;
+using MediaBrowser.Model.Plugins;
+using MediaBrowser.Model.Serialization;
+using MediaBrowser.Model.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Xtream;
+
+/// <summary>
+/// The main plugin.
+/// </summary>
+public class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
+{
+    private static Plugin? _instance;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Plugin"/> class.
+    /// </summary>
+    /// <param name="applicationPaths">Instance of the <see cref="IApplicationPaths"/> interface.</param>
+    /// <param name="xmlSerializer">Instance of the <see cref="IXmlSerializer"/> interface.</param>
+    /// <param name="taskManager">Instance of the <see cref="ITaskManager"/> interface.</param>
+    /// <param name="xtreamClient">Instance of the <see cref="IXtreamClient"/> interface.</param>
+    public Plugin(IApplicationPaths applicationPaths, IXmlSerializer xmlSerializer, ITaskManager taskManager, IXtreamClient xtreamClient)
+        : base(applicationPaths, xmlSerializer)
+    {
+        _instance = this;
+        StreamService = new(xtreamClient);
+        TaskService = new(taskManager);
+    }
+
+    /// <inheritdoc />
+    public override string Name => "Jellyfin Xtream";
+
+    /// <inheritdoc />
+    public override Guid Id => Guid.Parse("5d774c35-8567-46d3-a950-9bb8227a0c5d");
+
+    /// <summary>
+    /// Gets the Xtream connection info with credentials.
+    /// </summary>
+    public ConnectionInfo Creds => new(Configuration.BaseUrl, Configuration.Username, Configuration.Password);
+
+    /// <summary>
+    /// Gets the data version used to trigger a cache invalidation on plugin update or config change.
+    /// </summary>
+    public string DataVersion => Assembly.GetCallingAssembly().GetName().Version?.ToString() + Configuration.GetHashCode();
+
+    /// <summary>
+    /// Gets the current plugin instance.
+    /// </summary>
+    public static Plugin Instance => _instance ?? throw new InvalidOperationException("Plugin instance not available");
+
+    /// <summary>
+    /// Gets the stream service instance.
+    /// </summary>
+    public StreamService StreamService { get; init; }
+
+    /// <summary>
+    /// Gets the task service instance.
+    /// </summary>
+    public TaskService TaskService { get; init; }
+
+    private static PluginPageInfo CreateStatic(string name) => new()
+    {
+        Name = name,
+        EmbeddedResourcePath = string.Format(
+            CultureInfo.InvariantCulture,
+            "{0}.Configuration.Web.{1}",
+            typeof(Plugin).Namespace,
+            name),
+    };
+
+    /// <inheritdoc />
+    public IEnumerable<PluginPageInfo> GetPages()
+    {
+        return new[]
+        {
+            CreateStatic("XtreamCredentials.html"),
+            CreateStatic("XtreamCredentials.js"),
+            CreateStatic("Xtream.css"),
+            CreateStatic("Xtream.js"),
+            CreateStatic("XtreamLive.html"),
+            CreateStatic("XtreamLive.js"),
+            CreateStatic("XtreamLiveOverrides.html"),
+            CreateStatic("XtreamLiveOverrides.js"),
+            CreateStatic("XtreamSeries.html"),
+            CreateStatic("XtreamSeries.js"),
+            CreateStatic("XtreamVod.html"),
+            CreateStatic("XtreamVod.js"),
+        };
+    }
+
+    /// <inheritdoc />
+    public override void UpdateConfiguration(BasePluginConfiguration configuration)
+    {
+        base.UpdateConfiguration(configuration);
+
+        // Force a refresh of TV guide on configuration update.
+        // - This will update the TV channels.
+        // - This will remove channels on credentials change.
+        TaskService.CancelIfRunningAndQueue(
+            "Jellyfin.LiveTv",
+            "Jellyfin.LiveTv.Guide.RefreshGuideScheduledTask");
+
+        // Force a refresh of Channels on configuration update.
+        // - This will update the channel entries.
+        // - This will remove channel entries on credentials change.
+        TaskService.CancelIfRunningAndQueue(
+            "Jellyfin.LiveTv",
+            "Jellyfin.LiveTv.Channels.RefreshChannelsScheduledTask");
+    }
+}
+--- END OF FILE: ./Jellyfin.Xtream/Plugin.cs ---
+
+--- START OF FILE: ./Jellyfin.Xtream/Providers/XtreamVodProvider.cs ---
+// Copyright (C) 2022  Kevin Jilissen
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Xtream.Client;
+using Jellyfin.Xtream.Client.Models;
+using Jellyfin.Xtream.Service;
+using MediaBrowser.Controller.Entities.Movies;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.Providers;
+using MediaBrowser.Model.Entities;
+using MediaBrowser.Model.Providers;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Xtream.Providers;
+
+/// <summary>
+/// The Xtream Codes VOD metadata provider.
+/// </summary>
+/// <param name="logger">Instance of the <see cref="ILogger"/> interface.</param>
+/// <param name="providerManager">Instance of the <see cref="IProviderManager"/> interface.</param>
+/// <param name="xtreamClient">Instance of the <see cref="IXtreamClient"/> interface.</param>
+public class XtreamVodProvider(ILogger<VodChannel> logger, IProviderManager providerManager, IXtreamClient xtreamClient) : ICustomMetadataProvider<Movie>, IPreRefreshProvider
+{
+    /// <summary>
+    /// The name of the provider.
+    /// </summary>
+    public const string ProviderName = "XtreamVodProvider";
+
+    /// <inheritdoc/>
+    public string Name => ProviderName;
+
+    /// <inheritdoc/>
+    public async Task<ItemUpdateType> FetchAsync(Movie item, MetadataRefreshOptions options, CancellationToken cancellationToken)
+    {
+        string? idStr = item.GetProviderId(ProviderName);
+        if (idStr is not null)
+        {
+            logger.LogDebug("Getting metadata for movie {Id}", idStr);
+            int id = int.Parse(idStr, CultureInfo.InvariantCulture);
+            VodStreamInfo vod = await xtreamClient.GetVodInfoAsync(Plugin.Instance.Creds, id, cancellationToken).ConfigureAwait(false);
+            VodInfo? i = vod.Info;
+
+            if (i is null)
+            {
+                return ItemUpdateType.None;
+            }
+
+            item.Overview ??= i.Plot;
+            item.PremiereDate ??= i.ReleaseDate;
+            item.RunTimeTicks ??= i.DurationSecs * TimeSpan.TicksPerSecond;
+            item.TotalBitrate ??= i.Bitrate;
+
+            if (i.Genre is string genres)
+            {
+                item.Genres ??= genres.Split(',').Select(genre => genre.Trim()).ToArray();
+            }
+
+            if (!item.HasProviderId(MetadataProvider.Tmdb))
+            {
+                if (i.TmdbId is int tmdbId)
+                {
+                    options.ReplaceAllMetadata = true;
+                    item.SetProviderId(MetadataProvider.Tmdb, tmdbId.ToString(CultureInfo.InvariantCulture));
+                }
+                else if (Plugin.Instance.Configuration.IsTmdbVodOverride)
+                {
+                    // Try to fetch the TMDB id to get proper metadata.
+                    RemoteSearchQuery<MovieInfo> query = new()
+                    {
+                        SearchInfo = new()
+                        {
+                            Name = StreamService.ParseName(vod.MovieData?.Name ?? string.Empty).Title,
+                            Year = item.PremiereDate?.Year,
+                        },
+                        SearchProviderName = "TheMovieDb",
+                    };
+                    IEnumerable<RemoteSearchResult> results = await providerManager.GetRemoteSearchResults<Movie, MovieInfo>(query, cancellationToken).ConfigureAwait(false);
+                    if (results.Any())
+                    {
+                        RemoteSearchResult tmdbMovie = results.First();
+                        if (tmdbMovie.HasProviderId(MetadataProvider.Tmdb))
+                        {
+                            string? queryId = tmdbMovie.GetProviderId(MetadataProvider.Tmdb);
+                            if (queryId is not null)
+                            {
+                                options.ReplaceAllMetadata = true;
+                                item.SetProviderId(MetadataProvider.Tmdb, queryId);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        return ItemUpdateType.MetadataImport;
+    }
+}
+--- END OF FILE: ./Jellyfin.Xtream/Providers/XtreamVodProvider.cs ---
+
+--- START OF FILE: ./Jellyfin.Xtream/SeriesChannel.cs ---
+// Copyright (C) 2022  Kevin Jilissen
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Xtream.Client.Models;
+using Jellyfin.Xtream.Service;
+using MediaBrowser.Controller.Channels;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Providers;
+using MediaBrowser.Model.Channels;
+using MediaBrowser.Model.Dto;
+using MediaBrowser.Model.Entities;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Xtream;
+
+/// <summary>
+/// The Xtream Codes API channel.
+/// </summary>
+/// <param name="logger">Instance of the <see cref="ILogger"/> interface.</param>
+public class SeriesChannel(ILogger<SeriesChannel> logger) : IChannel, IDisableMediaSourceDisplay
+{
+    /// <inheritdoc />
+    public string? Name => "Xtream Series";
+
+    /// <inheritdoc />
+    public string? Description => "Series streamed from the Xtream-compatible server.";
+
+    /// <inheritdoc />
+    public string DataVersion => Plugin.Instance.DataVersion;
+
+    /// <inheritdoc />
+    public string HomePageUrl => string.Empty;
+
+    /// <inheritdoc />
+    public ChannelParentalRating ParentalRating => ChannelParentalRating.GeneralAudience;
+
+    /// <inheritdoc />
+    public InternalChannelFeatures GetChannelFeatures()
+    {
+        return new InternalChannelFeatures
+        {
+            ContentTypes = [
+                ChannelMediaContentType.Episode,
+            ],
+
+            MediaTypes = [
+                ChannelMediaType.Video
+            ],
+        };
+    }
+
+    /// <inheritdoc />
+    public Task<DynamicImageResponse> GetChannelImage(ImageType type, CancellationToken cancellationToken)
+    {
+        switch (type)
+        {
+            default:
+                throw new ArgumentException("Unsupported image type: " + type);
+        }
+    }
+
+    /// <inheritdoc />
+    public IEnumerable<ImageType> GetSupportedChannelImages()
+    {
+        return new List<ImageType>
+        {
+            // ImageType.Primary
+        };
+    }
+
+    /// <inheritdoc />
+    public async Task<ChannelItemResult> GetChannelItems(InternalChannelItemQuery query, CancellationToken cancellationToken)
+    {
+        try
+        {
+            if (string.IsNullOrEmpty(query.FolderId))
+            {
+                return await GetCategories(cancellationToken).ConfigureAwait(false);
+            }
+
+            Guid guid = Guid.Parse(query.FolderId);
+            StreamService.FromGuid(guid, out int prefix, out int categoryId, out int seriesId, out int seasonId);
+            if (prefix == StreamService.SeriesCategoryPrefix)
+            {
+                return await GetSeries(categoryId, cancellationToken).ConfigureAwait(false);
+            }
+
+            if (prefix == StreamService.SeriesPrefix)
+            {
+                return await GetSeasons(seriesId, cancellationToken).ConfigureAwait(false);
+            }
+
+            if (prefix == StreamService.SeasonPrefix)
+            {
+                return await GetEpisodes(seriesId, seasonId, cancellationToken).ConfigureAwait(false);
+            }
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to get channel items");
+            throw;
+        }
+
+        return new ChannelItemResult()
+        {
+            TotalRecordCount = 0,
+        };
+    }
+
+    private ChannelItemInfo CreateChannelItemInfo(Series series)
+    {
+        ParsedName parsedName = StreamService.ParseName(series.Name);
+        return new ChannelItemInfo()
+        {
+            CommunityRating = (float)series.Rating5Based,
+            DateModified = series.LastModified,
+            FolderType = ChannelFolderType.Series,
+            Genres = GetGenres(series.Genre),
+            Id = StreamService.ToGuid(StreamService.SeriesPrefix, series.CategoryId, series.SeriesId, 0).ToString(),
+            ImageUrl = series.Cover,
+            Name = parsedName.Title,
+            SeriesName = parsedName.Title,
+            People = GetPeople(series.Cast),
+            Tags = new List<string>(parsedName.Tags),
+            Type = ChannelItemType.Folder,
+        };
+    }
+
+    private static List<string> GetGenres(string genreString)
+    {
+        return new(genreString.Split(',').Select(genre => genre.Trim()));
+    }
+
+    private static List<PersonInfo> GetPeople(string cast)
+    {
+        return cast.Split(',').Select(name => new PersonInfo()
+        {
+            Name = name.Trim()
+        }).ToList();
+    }
+
+    private ChannelItemInfo CreateChannelItemInfo(int seriesId, SeriesStreamInfo series, int seasonId)
+    {
+        Client.Models.SeriesInfo serie = series.Info;
+        string name = $"Season {seasonId}";
+        string cover = series.Info.Cover;
+        string? overview = null;
+        DateTime? created = null;
+        List<string> tags = [];
+
+        Season? season = series.Seasons.FirstOrDefault(s => s.SeasonId == seasonId);
+        if (season != null)
+        {
+            ParsedName parsedName = StreamService.ParseName(season.Name);
+            name = parsedName.Title;
+            tags.AddRange(parsedName.Tags);
+            created = season.AirDate;
+            overview = season.Overview;
+            if (!string.IsNullOrEmpty(season.Cover))
+            {
+                cover = season.Cover;
+            }
+        }
+
+        return new()
+        {
+            DateCreated = created,
+            FolderType = ChannelFolderType.Season,
+            Genres = GetGenres(serie.Genre),
+            Id = StreamService.ToGuid(StreamService.SeasonPrefix, serie.CategoryId, seriesId, seasonId).ToString(),
+            IndexNumber = seasonId,
+            Name = name,
+            Overview = overview,
+            People = GetPeople(serie.Cast),
+            Tags = tags,
+            Type = ChannelItemType.Folder,
+        };
+    }
+
+    private ChannelItemInfo CreateChannelItemInfo(SeriesStreamInfo series, Season? season, Episode episode)
+    {
+        Client.Models.SeriesInfo serie = series.Info;
+        ParsedName parsedName = StreamService.ParseName(episode.Title);
+        List<MediaSourceInfo> sources =
+        [
+            Plugin.Instance.StreamService.GetMediaSourceInfo(
+                StreamType.Series,
+                episode.EpisodeId,
+                episode.ContainerExtension,
+                videoInfo: episode.Info?.Video,
+                audioInfo: episode.Info?.Audio)
+        ];
+
+        string? cover = episode.Info?.MovieImage;
+        cover ??= season?.Cover;
+        cover ??= serie.Cover;
+
+        return new()
+        {
+            ContentType = ChannelMediaContentType.Episode,
+            DateCreated = episode.Added,
+            Genres = GetGenres(serie.Genre),
+            Id = StreamService.ToGuid(StreamService.EpisodePrefix, 0, 0, episode.EpisodeId).ToString(),
+            IndexNumber = episode.EpisodeNum,
+            IsLiveStream = false,
+            MediaSources = sources,
+            MediaType = ChannelMediaType.Video,
+            Name = $"Episode {episode.EpisodeNum}",
+            Overview = episode.Info?.Plot,
+            ParentIndexNumber = episode.Season,
+            People = GetPeople(serie.Cast),
+            RunTimeTicks = episode.Info?.DurationSecs * TimeSpan.TicksPerSecond,
+            Tags = new(parsedName.Tags),
+            Type = ChannelItemType.Media,
+        };
+    }
+
+    private async Task<ChannelItemResult> GetCategories(CancellationToken cancellationToken)
+    {
+        IEnumerable<Category> categories = await Plugin.Instance.StreamService.GetSeriesCategories(cancellationToken).ConfigureAwait(false);
+        List<ChannelItemInfo> items = new(
+            categories.Select((Category category) => StreamService.CreateChannelItemInfo(StreamService.SeriesCategoryPrefix, category)));
+        return new()
+        {
+            Items = items,
+            TotalRecordCount = items.Count
+        };
+    }
+
+    private async Task<ChannelItemResult> GetSeries(int categoryId, CancellationToken cancellationToken)
+    {
+        IEnumerable<Series> series = await Plugin.Instance.StreamService.GetSeries(categoryId, cancellationToken).ConfigureAwait(false);
+        List<ChannelItemInfo> items = new(series.Select(CreateChannelItemInfo));
+        return new()
+        {
+            Items = items,
+            TotalRecordCount = items.Count
+        };
+    }
+
+    private async Task<ChannelItemResult> GetSeasons(int seriesId, CancellationToken cancellationToken)
+    {
+        IEnumerable<Tuple<SeriesStreamInfo, int>> seasons = await Plugin.Instance.StreamService.GetSeasons(seriesId, cancellationToken).ConfigureAwait(false);
+        List<ChannelItemInfo> items = new(
+            seasons.Select((Tuple<SeriesStreamInfo, int> tuple) => CreateChannelItemInfo(seriesId, tuple.Item1, tuple.Item2)));
+        return new()
+        {
+            Items = items,
+            TotalRecordCount = items.Count
+        };
+    }
+
+    private async Task<ChannelItemResult> GetEpisodes(int seriesId, int seasonId, CancellationToken cancellationToken)
+    {
+        IEnumerable<Tuple<SeriesStreamInfo, Season?, Episode>> episodes = await Plugin.Instance.StreamService.GetEpisodes(seriesId, seasonId, cancellationToken).ConfigureAwait(false);
+        List<ChannelItemInfo> items = new List<ChannelItemInfo>(
+            episodes.Select((Tuple<SeriesStreamInfo, Season?, Episode> tuple) => CreateChannelItemInfo(tuple.Item1, tuple.Item2, tuple.Item3)));
+        return new()
+        {
+            Items = items,
+            TotalRecordCount = items.Count
+        };
+    }
+
+    /// <inheritdoc />
+    public bool IsEnabledFor(string userId)
+    {
+        return Plugin.Instance.Configuration.IsSeriesVisible;
+    }
+}
+--- END OF FILE: ./Jellyfin.Xtream/SeriesChannel.cs ---
+
+--- START OF FILE: ./Jellyfin.Xtream/Configuration/PluginConfiguration.cs ---
+// Copyright (C) 2022  Kevin Jilissen
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System.Collections.Generic;
+using MediaBrowser.Model.Plugins;
+
+#pragma warning disable CA2227
+namespace Jellyfin.Xtream.Configuration;
+
+/// <summary>
+/// Plugin configuration.
+/// </summary>
+public class PluginConfiguration : BasePluginConfiguration
+{
+    /// <summary>
+    /// Gets or sets the base url including protocol and trailing slash.
+    /// </summary>
+    public string BaseUrl { get; set; } = "https://example.com";
+
+    /// <summary>
+    /// Gets or sets the username.
+    /// </summary>
+    public string Username { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the password.
+    /// </summary>
+    public string Password { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the Catch-up channel is visible.
+    /// </summary>
+    public bool IsCatchupVisible { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the Series channel is visible.
+    /// </summary>
+    public bool IsSeriesVisible { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the Video On-demand channel is visible.
+    /// </summary>
+    public bool IsVodVisible { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the Video On-demand channel is visible.
+    /// </summary>
+    public bool IsTmdbVodOverride { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets the channels displayed in Live TV.
+    /// </summary>
+    public SerializableDictionary<int, HashSet<int>> LiveTv { get; set; } = [];
+
+    /// <summary>
+    /// Gets or sets the streams displayed in VOD.
+    /// </summary>
+    public SerializableDictionary<int, HashSet<int>> Vod { get; set; } = [];
+
+    /// <summary>
+    /// Gets or sets the streams displayed in Series.
+    /// </summary>
+    public SerializableDictionary<int, HashSet<int>> Series { get; set; } = [];
+
+    /// <summary>
+    /// Gets or sets the channel override configuration for Live TV.
+    /// </summary>
+    public SerializableDictionary<int, ChannelOverrides> LiveTvOverrides { get; set; } = [];
+}
+#pragma warning restore CA2227
+--- END OF FILE: ./Jellyfin.Xtream/Configuration/PluginConfiguration.cs ---
+
+--- START OF FILE: ./Jellyfin.Xtream/Configuration/Web/Xtream.js ---
+const url = (name) =>
+  ApiClient.getUrl("configurationpage", {
+    name,
+  });
+const tab = (name) => '/configurationpage?name=' + name + '.html';
+
+$(document).ready(() => {
+  const style = document.createElement('link');
+  style.rel = 'stylesheet';
+  style.href = url('Xtream.css')
+  document.head.appendChild(style);
+});
+
+const htmlExpand = document.createElement('span');
+htmlExpand.ariaHidden = true;
+htmlExpand.classList.add('material-icons', 'expand_more');
+
+const createItemRow = (item, state, update) => {
+  const tr = document.createElement('tr');
+  tr.dataset['itemId'] = item.Id;
+
+  let td = document.createElement('td');
+  const checkbox = document.createElement('input');
+  checkbox.type = 'checkbox';
+  checkbox.checked = state;
+  checkbox.onchange = update;
+  td.appendChild(checkbox);
+  tr.appendChild(td);
+
+  td = document.createElement('td');
+  const label = document.createElement('label');
+  label.innerText = item.Name;
+  td.appendChild(label);
+  tr.appendChild(td);
+
+  td = document.createElement('td');
+  if (item.HasCatchup) {
+    td.title = `Catch-up supported for ${item.CatchupDuration} days.`;
+
+    let span = document.createElement('span');
+    span.innerText = item.CatchupDuration;
+    td.appendChild(span);
+
+    span = document.createElement('span');
+    span.ariaHidden = true;
+    span.classList.add('material-icons', 'timer');
+    td.appendChild(span);
+  }
+  tr.appendChild(td);
+
+  return tr;
+}
+
+const populateItemsTable = (wrapper, table, items) => {
+  for (let i = 0; i < items.length; ++i) {
+    const item = items[i];
+    const state = wrapper.live !== undefined && (wrapper.live.length === 0 || wrapper.live.includes(item.Id));
+    const row = createItemRow(item, state, (e) => {
+      let live = wrapper.live;
+      if (e.target.checked) {
+        live ??= [];
+        live.push(item.Id);
+        if (items.every(s => live.includes(s.Id))) {
+          live = [];
+        }
+      } else {
+        if (live.length === 0) {
+          live = items.map(s => s.Id);
+        }
+        live = live.filter(id => id != item.Id);
+        if (live.length === 0) {
+          live = undefined;
+        }
+      }
+      wrapper.live = live;
+    });
+    table.appendChild(row);
+  }
+}
+
+const setCheckboxState = (checkbox, live) => {
+  checkbox.indeterminate = live !== undefined && live.length > 0;
+  checkbox.checked = live !== undefined && live.length === 0;
+}
+
+const createCategoryRow = (wrapper, category, loadItems) => {
+  const tr = document.createElement('tr');
+  tr.dataset['categoryId'] = category.Id;
+
+  let td = document.createElement('td');
+  const checkbox = document.createElement('input');
+  checkbox.type = 'checkbox';
+  setCheckboxState(checkbox, wrapper.live);
+  const onchange = () => {
+    if (checkbox.checked) {
+      wrapper.live = [];
+    } else {
+      wrapper.live = undefined;
+    }
+  };
+  checkbox.onchange = onchange;
+  td.appendChild(checkbox);
+  tr.appendChild(td);
+
+  const _wrapper = {
+    get live() { return wrapper.live; },
+    set live(value) {
+      wrapper.live = value;
+      setCheckboxState(checkbox, wrapper.live);
+    },
+  }
+
+  td = document.createElement('td');
+  td.innerHTML = category.Name;
+  tr.appendChild(td);
+
+  td = document.createElement('td');
+  const expand = document.createElement('button');
+  expand.type = 'button';
+  expand.classList.add('paper-icon-button-light');
+  expand.appendChild(htmlExpand.cloneNode(true));
+  expand.onclick = (e) => {
+    e.preventDefault();
+    const originalClick = expand.onclick;
+
+    Dashboard.showLoadingMsg();
+    expand.firstElementChild.classList.replace('expand_more', 'expand_less');
+    const table = document.createElement('table');
+    loadItems(category.Id).then((items) => {
+      populateItemsTable(_wrapper, table, items);
+      Dashboard.hideLoadingMsg();
+    });
+    checkbox.onchange = () => {
+      onchange();
+      table.querySelectorAll('input[type="checkbox"]').forEach((c) => c.checked = checkbox.checked);
+    };
+    td.appendChild(table);
+
+    expand.onclick = () => {
+      expand.onclick = originalClick;
+
+      Dashboard.showLoadingMsg();
+      expand.firstElementChild.classList.replace('expand_less', 'expand_more');
+      td.removeChild(table);
+      Dashboard.hideLoadingMsg();
+    };
+  };
+  td.appendChild(expand);
+  tr.appendChild(td);
+
+  return tr;
+};
+
+const populateCategoriesTable = (table, loadConfig, loadCategories, loadItems) => {
+  Dashboard.showLoadingMsg();
+  const fetchConfig = loadConfig();
+  const fetchCategories = loadCategories();
+
+  return Promise.all([fetchConfig, fetchCategories])
+    .then(([config, categories]) => {
+      const data = config;
+      for (let i = 0; i < categories.length; ++i) {
+        const category = categories[i];
+        const wrapper = {
+          get live() { return data[category.Id]; },
+          set live(value) {
+            data[category.Id] = value;
+          },
+        }
+        const elem = createCategoryRow(wrapper, category, loadItems);
+        table.appendChild(elem);
+      }
+      Dashboard.hideLoadingMsg();
+      return data;
+    });
+}
+
+const fetchJson = (url) => ApiClient.fetch({
+  dataType: 'json',
+  type: 'GET',
+  url: ApiClient.getUrl(url),
+});
+
+const filter = (obj, predicate) => Object.keys(obj)
+  .filter(key => predicate(obj[key]))
+  .reduce((res, key) => (res[key] = obj[key], res), {});
+
+const tabs = [
+  {
+    href: tab('XtreamCredentials'),
+    name: 'Credentials'
+  },
+  {
+    href: tab('XtreamLive'),
+    name: 'Live TV'
+  },
+  {
+    href: tab('XtreamLiveOverrides'),
+    name: 'TV overrides'
+  },
+  {
+    href: tab('XtreamVod'),
+    name: 'Video On-Demand',
+  },
+  {
+    href: tab('XtreamSeries'),
+    name: 'Series',
+  },
+];
+
+const setTabs = (index) => {
+  const name = tabs[index].name;
+  LibraryMenu.setTabs(name, index, () => tabs);
+}
+
+const pluginConfig = {
+  UniqueId: '5d774c35-8567-46d3-a950-9bb8227a0c5d'
+};
+
+export default {
+  fetchJson,
+  filter,
+  pluginConfig,
+  populateCategoriesTable,
+  setTabs,
+}
+--- END OF FILE: ./Jellyfin.Xtream/Configuration/Web/Xtream.js ---
+
+--- START OF FILE: ./Jellyfin.Xtream/Configuration/Web/XtreamVod.html ---
+<div id="XtreamVodPage" data-role="page" class="page type-interior pluginConfigurationPage withTabs"
+  data-require="emby-input,emby-button" data-controller="__plugin/XtreamVod.js">
+  <div data-role="content">
+    <div class="content-primary">
+      <form id="XtreamVodForm">
+        <div class="checkboxContainer checkboxContainer-withDescription">
+          <label>
+            <input is="emby-checkbox" id="Visible" name="Visible" type="checkbox" />
+            <span>Show this channel to users</span>
+          </label>
+        </div>
+        <div class="checkboxContainer checkboxContainer-withDescription">
+          <label>
+            <input is="emby-checkbox" id="TmdbOverride" name="TmdbOverride" type="checkbox" />
+            <span>Override metadata with TMDB</span>
+          </label>
+        </div>
+        <div class="sectionTitleContainer flex align-items-center">
+          <h2 class="sectionTitle">Video On-demand selection</h2>
+        </div>
+        <div class="inputContainer">
+          <table class="categories-table">
+            <thead>
+              <tr>
+                <th colspan="2">Category</th>
+                <th>Display</th>
+              </tr>
+            </thead>
+            <tbody id="VodContent">
+
+            </tbody>
+          </table>
+        </div>
+        <div>
+          <button is="emby-button" type="submit" class="raised button-submit block emby-button">
+            <span>Save</span>
+          </button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>--- END OF FILE: ./Jellyfin.Xtream/Configuration/Web/XtreamVod.html ---
+
+--- START OF FILE: ./Jellyfin.Xtream/Configuration/Web/XtreamVod.js ---
+export default function (view) {
+  view.addEventListener("viewshow", () => import(
+    ApiClient.getUrl("web/ConfigurationPage", {
+      name: "Xtream.js",
+    })
+  ).then((Xtream) => Xtream.default
+  ).then((Xtream) => {
+    const pluginId = Xtream.pluginConfig.UniqueId;
+    Xtream.setTabs(3);
+
+    const getConfig = ApiClient.getPluginConfiguration(pluginId);
+    const visible = view.querySelector("#Visible");
+    getConfig.then((config) => visible.checked = config.IsVodVisible);
+    const tmdbOverride = view.querySelector("#TmdbOverride");
+    getConfig.then((config) => TmdbOverride.checked = config.IsTmdbVodOverride);
+    const table = view.querySelector('#VodContent');
+    Xtream.populateCategoriesTable(
+      table,
+      () => getConfig.then((config) => config.Vod),
+      () => Xtream.fetchJson('Xtream/VodCategories'),
+      (categoryId) => Xtream.fetchJson(`Xtream/VodCategories/${categoryId}`),
+    ).then((data) => {
+      view.querySelector('#XtreamVodForm').addEventListener('submit', (e) => {
+        Dashboard.showLoadingMsg();
+
+        ApiClient.getPluginConfiguration(pluginId).then((config) => {
+          config.IsVodVisible = visible.checked;
+          config.IsTmdbVodOverride = tmdbOverride.checked;
+          config.Vod = data;
+          ApiClient.updatePluginConfiguration(pluginId, config).then((result) => {
+            Dashboard.processPluginConfigurationUpdateResult(result);
+          });
+        });
+
+        e.preventDefault();
+        return false;
+      });
+    });
+  }));
+}--- END OF FILE: ./Jellyfin.Xtream/Configuration/Web/XtreamVod.js ---
+
+--- START OF FILE: ./Jellyfin.Xtream/Configuration/Web/XtreamLive.html ---
+<div id="XtreamLivePage" data-role="page" class="page type-interior pluginConfigurationPage withTabs"
+  data-require="emby-input,emby-button" data-controller="__plugin/XtreamLive.js">
+  <div data-role="content">
+    <div class="content-primary">
+      <form id="XtreamLiveForm">
+        <div class="checkboxContainer checkboxContainer-withDescription">
+          <label>
+            <input is="emby-checkbox" id="Visible" name="Visible" type="checkbox" />
+            <span>Show the catch-up channel to users</span>
+          </label>
+        </div>
+        <div class="sectionTitleContainer flex align-items-center">
+          <h2 class="sectionTitle">Channel selection</h2>
+        </div>
+        <div class="inputContainer">
+          <table class="categories-table">
+            <thead>
+              <tr>
+                <th colspan="2">Category</th>
+                <th>Display</th>
+              </tr>
+            </thead>
+            <tbody id="LiveContent">
+
+            </tbody>
+          </table>
+        </div>
+        <div>
+          <button is="emby-button" type="submit" class="raised button-submit block emby-button">
+            <span>Save</span>
+          </button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>--- END OF FILE: ./Jellyfin.Xtream/Configuration/Web/XtreamLive.html ---
+
+--- START OF FILE: ./Jellyfin.Xtream/Configuration/Web/XtreamLiveOverrides.html ---
+<div id="XtreamLivePage" data-role="page" class="page type-interior pluginConfigurationPage withTabs"
+  data-require="emby-input,emby-button" data-controller="__plugin/XtreamLiveOverrides.js">
+  <div data-role="content">
+    <div class="content-primary">
+      <form id="XtreamLiveOverridesForm">
+        <div class="sectionTitleContainer flex align-items-center">
+          <h2 class="sectionTitle">TV channel overrides</h2>
+        </div>
+        <div class="inputContainer">
+          <table class="overrides-table">
+            <thead>
+              <tr>
+                <th>Number</th>
+                <th>Name</th>
+                <th>Logo</th>
+              </tr>
+            </thead>
+            <tbody id="LiveChannels">
+
+            </tbody>
+          </table>
+        </div>
+        <div>
+          <button is="emby-button" type="submit" class="raised button-submit block emby-button">
+            <span>Save</span>
+          </button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>--- END OF FILE: ./Jellyfin.Xtream/Configuration/Web/XtreamLiveOverrides.html ---
+
+--- START OF FILE: ./Jellyfin.Xtream/Configuration/Web/XtreamSeries.html ---
+<div id="XtreamSeriesPage" data-role="page" class="page type-interior pluginConfigurationPage withTabs"
+  data-require="emby-input,emby-button" data-controller="__plugin/XtreamSeries.js">
+  <div data-role="content">
+    <div class="content-primary">
+      <form id="XtreamSeriesForm">
+        <div class="checkboxContainer checkboxContainer-withDescription">
+          <label>
+            <input is="emby-checkbox" id="Visible" name="Visible" type="checkbox" />
+            <span>Show this channel to users</span>
+          </label>
+        </div>
+        <div class="sectionTitleContainer flex align-items-center">
+          <h2 class="sectionTitle">Series selection</h2>
+        </div>
+        <div class="inputContainer">
+          <table class="categories-table">
+            <thead>
+              <tr>
+                <th colspan="2">Category</th>
+                <th>Display</th>
+              </tr>
+            </thead>
+            <tbody id="SeriesContent">
+
+            </tbody>
+          </table>
+        </div>
+        <div>
+          <button is="emby-button" type="submit" class="raised button-submit block emby-button">
+            <span>Save</span>
+          </button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>--- END OF FILE: ./Jellyfin.Xtream/Configuration/Web/XtreamSeries.html ---
+
+--- START OF FILE: ./Jellyfin.Xtream/Configuration/Web/Xtream.css ---
+.categories-table {
+  border-collapse: collapse;
+  width: 100%;
+}
+
+.categories-table th:nth-child(1) {
+  min-width: 30%;
+}
+
+.categories-table th:nth-child(2),
+.categories-table tr[data-category-id]>td:nth-child(3),
+.categories-table tr[data-item-id]>td:nth-child(2) {
+  width: 100%;
+}
+
+.categories-table tbody {
+  vertical-align: baseline;
+}
+
+.categories-table tr[data-item-id]>td:nth-child(3) {
+  white-space: nowrap;
+  padding: 0.3em 0;
+}
+
+.categories-table tr[data-item-id]>td:nth-child(3)>span {
+  font-size: 1em;
+  vertical-align: middle;
+}
+
+.overrides-table {
+  width: 100%;
+}
+
+.overrides-table thead th:first-child {
+  width: 0;
+}
+--- END OF FILE: ./Jellyfin.Xtream/Configuration/Web/Xtream.css ---
+
+--- START OF FILE: ./Jellyfin.Xtream/Configuration/Web/XtreamCredentials.html ---
+<div id="XtreamCredentialsPage" data-role="page" class="page type-interior pluginConfigurationPage withTabs"
+  data-require="emby-input,emby-button" data-controller="__plugin/XtreamCredentials.js">
+  <div data-role="content">
+    <div class="content-primary">
+      <form id="XtreamCredentialsForm">
+        <div class="inputContainer">
+          <label class="inputLabel inputLabelUnfocused" for="BaseUrl">Base URL</label>
+          <input id="BaseUrl" name="BaseUrl" type="url" is="emby-input" />
+          <div class="fieldDescription">
+            The base url including protocol without trailing slash.
+          </div>
+        </div>
+        <div class="inputContainer">
+          <label class="inputLabel inputLabelUnfocused" for="Username">Username</label>
+          <input id="Username" name="Username" type="text" is="emby-input" />
+          <div class="fieldDescription">The username.</div>
+        </div>
+        <div class="inputContainer">
+          <label class="inputLabel inputLabelUnfocused" for="Password">Password</label>
+          <input id="Password" name="Password" type="password" is="emby-input" />
+          <div class="fieldDescription">The password.</div>
+        </div>
+        <div>
+          <button is="emby-button" type="submit" class="raised button-submit block emby-button">
+            <span>Save</span>
+          </button>
+        </div>
+      </form>
+      <div id="ProviderTest">
+        <h2>Provider status</h2>
+        <table>
+          <tr>
+            <td>Status</td>
+            <td id="ProviderStatus"></td>
+          </tr>
+          <tr>
+            <td>Account expiry date</td>
+            <td id="ProviderExpiry"></td>
+          </tr>
+          <tr>
+            <td>Current active connections</td>
+            <td id="ProviderConnections"></td>
+          </tr>
+          <tr>
+            <td>Max active connections</td>
+            <td id="ProviderMaxConnections"></td>
+          </tr>
+          <tr>
+            <td>Provider server time</td>
+            <td id="ProviderTime"></td>
+          </tr>
+          <tr>
+            <td>Provider server timezone</td>
+            <td id="ProviderTimezone"></td>
+          </tr>
+          <tr>
+            <td>Supports MPEG-TS</td>
+            <td id="ProviderMpegTs"></td>
+          </tr>
+        </table>
+      </div>
+    </div>
+  </div>
+</div>--- END OF FILE: ./Jellyfin.Xtream/Configuration/Web/XtreamCredentials.html ---
+
+--- START OF FILE: ./Jellyfin.Xtream/Configuration/Web/XtreamSeries.js ---
+export default function (view) {
+  view.addEventListener("viewshow", () => import(
+    ApiClient.getUrl("web/ConfigurationPage", {
+      name: "Xtream.js",
+    })
+  ).then((Xtream) => Xtream.default
+  ).then((Xtream) => {
+    const pluginId = Xtream.pluginConfig.UniqueId;
+    Xtream.setTabs(4);
+
+    const getConfig = ApiClient.getPluginConfiguration(pluginId);
+    const visible = view.querySelector("#Visible");
+    getConfig.then((config) => visible.checked = config.IsSeriesVisible);
+    const table = view.querySelector('#SeriesContent');
+    Xtream.populateCategoriesTable(
+      table,
+      () => getConfig.then((config) => config.Series),
+      () => Xtream.fetchJson('Xtream/SeriesCategories'),
+      (categoryId) => Xtream.fetchJson(`Xtream/SeriesCategories/${categoryId}`),
+    ).then((data) => {
+      view.querySelector('#XtreamSeriesForm').addEventListener('submit', (e) => {
+        Dashboard.showLoadingMsg();
+
+        ApiClient.getPluginConfiguration(pluginId).then((config) => {
+          config.IsSeriesVisible = visible.checked;
+          config.Series = data;
+          ApiClient.updatePluginConfiguration(pluginId, config).then((result) => {
+            Dashboard.processPluginConfigurationUpdateResult(result);
+          });
+        });
+
+        e.preventDefault();
+        return false;
+      });
+    });
+  }));
+}--- END OF FILE: ./Jellyfin.Xtream/Configuration/Web/XtreamSeries.js ---
+
+--- START OF FILE: ./Jellyfin.Xtream/Configuration/Web/XtreamCredentials.js ---
+export default function (view) {
+  view.addEventListener("viewshow", () => import(
+    window.ApiClient.getUrl("web/ConfigurationPage", {
+      name: "Xtream.js",
+    })
+  ).then((Xtream) => Xtream.default
+  ).then((Xtream) => {
+    const pluginId = Xtream.pluginConfig.UniqueId;
+    Xtream.setTabs(0);
+
+    Dashboard.showLoadingMsg();
+    ApiClient.getPluginConfiguration(pluginId).then(function (config) {
+      view.querySelector('#BaseUrl').value = config.BaseUrl;
+      view.querySelector('#Username').value = config.Username;
+      view.querySelector('#Password').value = config.Password;
+      Dashboard.hideLoadingMsg();
+    });
+
+    const reloadStatus = () => {
+      const status = view.querySelector("#ProviderStatus");
+      const expiry = view.querySelector("#ProviderExpiry");
+      const cons = view.querySelector("#ProviderConnections");
+      const maxCons = view.querySelector("#ProviderMaxConnections");
+      const time = view.querySelector("#ProviderTime");
+      const timezone = view.querySelector("#ProviderTimezone");
+      const mpegTs = view.querySelector("#ProviderMpegTs");
+
+      Xtream.fetchJson('Xtream/TestProvider').then(response => {
+        status.innerText = response.Status;
+        expiry.innerText = response.ExpiryDate;
+        cons.innerText = response.ActiveConnections;
+        maxCons.innerText = response.MaxConnections;
+        time.innerText = response.ServerTime;
+        timezone.innerText = response.ServerTimezone;
+        mpegTs.innerText = response.SupportsMpegTs;
+      }).catch((_) => {
+        status.innerText = "Failed. Check server logs.";
+        expiry.innerText = "";
+        cons.innerText = "";
+        maxCons.innerText = "";
+        time.innerText = "";
+        timezone.innerText = "";
+        mpegTs.innerText = "";
+      });
+    };
+    reloadStatus();
+
+    view.querySelector('#XtreamCredentialsForm').addEventListener('submit', (e) => {
+      Dashboard.showLoadingMsg();
+
+      ApiClient.getPluginConfiguration(pluginId).then((config) => {
+        config.BaseUrl = view.querySelector('#BaseUrl').value;
+        config.Username = view.querySelector('#Username').value;
+        config.Password = view.querySelector('#Password').value;
+        ApiClient.updatePluginConfiguration(pluginId, config).then((result) => {
+          reloadStatus();
+          Dashboard.processPluginConfigurationUpdateResult(result);
+        });
+      });
+
+      e.preventDefault();
+      return false;
+    });
+  }));
+}--- END OF FILE: ./Jellyfin.Xtream/Configuration/Web/XtreamCredentials.js ---
+
+--- START OF FILE: ./Jellyfin.Xtream/Configuration/Web/XtreamLiveOverrides.js ---
+export default function (view) {
+  const createChannelRow = (channel, overrides) => {
+    const tr = document.createElement('tr');
+    tr.dataset['channelId'] = channel.Id;
+
+    let td = document.createElement('td');
+    const number = document.createElement('input');
+    number.type = 'number';
+    number.setAttribute('is', 'emby-input');
+    number.placeholder = channel.Number;
+    number.value = overrides.Number ?? '';
+    number.onchange = () => number.value ?
+      overrides.Number = parseInt(number.value) :
+      delete overrides.Number;
+    td.appendChild(number);
+    tr.appendChild(td);
+
+    td = document.createElement('td');
+    const name = document.createElement('input');
+    name.type = 'text';
+    name.setAttribute('is', 'emby-input');
+    name.placeholder = channel.Name;
+    name.value = overrides.Name ?? '';
+    name.onchange = () => name.value ?
+      overrides.Name = name.value :
+      delete overrides.Name;
+    td.appendChild(name);
+    tr.appendChild(td);
+
+    td = document.createElement('td');
+    const image = document.createElement('input');
+    image.type = 'text';
+    image.setAttribute('is', 'emby-input');
+    image.placeholder = channel.LogoUrl;
+    image.value = overrides.LogoUrl ?? '';
+    image.onchange = () => image.value ?
+      overrides.LogoUrl = image.value :
+      delete overrides.LogoUrl;
+    td.appendChild(image);
+    tr.appendChild(td);
+
+    return tr;
+  };
+
+  view.addEventListener("viewshow", () => import(
+    ApiClient.getUrl("web/ConfigurationPage", {
+      name: "Xtream.js",
+    })
+  ).then((Xtream) => Xtream.default
+  ).then((Xtream) => {
+    const pluginId = Xtream.pluginConfig.UniqueId;
+    Xtream.setTabs(2);
+
+    const getConfig = ApiClient.getPluginConfiguration(pluginId);
+    const table = view.querySelector('#LiveChannels');
+    Dashboard.showLoadingMsg();
+    Promise.all([
+      getConfig.then((config) => config.LiveTvOverrides),
+      Xtream.fetchJson('Xtream/LiveTv'),
+    ]).then(([data, channels]) => {
+      for (const channel of channels) {
+        data[channel.Id] ??= {};
+        const row = createChannelRow(channel, data[channel.Id]);
+        table.appendChild(row);
+      }
+      Dashboard.hideLoadingMsg();
+
+      view.querySelector('#XtreamLiveOverridesForm').addEventListener('submit', (e) => {
+        Dashboard.showLoadingMsg();
+
+        ApiClient.getPluginConfiguration(pluginId).then((config) => {
+          config.LiveTvOverrides = Xtream.filter(
+            data,
+            overrides => Object.keys(overrides).length > 0
+          );
+          ApiClient.updatePluginConfiguration(pluginId, config).then((result) => {
+            Dashboard.processPluginConfigurationUpdateResult(result);
+          });
+        });
+
+        e.preventDefault();
+        return false;
+      });
+    });
+  }));
+}--- END OF FILE: ./Jellyfin.Xtream/Configuration/Web/XtreamLiveOverrides.js ---
+
+--- START OF FILE: ./Jellyfin.Xtream/Configuration/Web/XtreamLive.js ---
+export default function (view) {
+  view.addEventListener("viewshow", () => import(
+    ApiClient.getUrl("web/ConfigurationPage", {
+      name: "Xtream.js",
+    })
+  ).then((Xtream) => Xtream.default
+  ).then((Xtream) => {
+    const pluginId = Xtream.pluginConfig.UniqueId;
+    Xtream.setTabs(1);
+
+    const getConfig = ApiClient.getPluginConfiguration(pluginId);
+    const visible = view.querySelector("#Visible");
+    getConfig.then((config) => visible.checked = config.IsCatchupVisible);
+    const table = view.querySelector('#LiveContent');
+    Xtream.populateCategoriesTable(
+      table,
+      () => getConfig.then((config) => config.LiveTv),
+      () => Xtream.fetchJson('Xtream/LiveCategories'),
+      (categoryId) => Xtream.fetchJson(`Xtream/LiveCategories/${categoryId}`),
+    ).then((data) => {
+      view.querySelector('#XtreamLiveForm').addEventListener('submit', (e) => {
+        Dashboard.showLoadingMsg();
+
+        ApiClient.getPluginConfiguration(pluginId).then((config) => {
+          config.IsCatchupVisible = visible.checked;
+          config.LiveTv = data;
+          ApiClient.updatePluginConfiguration(pluginId, config).then((result) => {
+            Dashboard.processPluginConfigurationUpdateResult(result);
+          });
+        });
+
+        e.preventDefault();
+        return false;
+      });
+    });
+  }));
+}--- END OF FILE: ./Jellyfin.Xtream/Configuration/Web/XtreamLive.js ---
+
+--- START OF FILE: ./Jellyfin.Xtream/Configuration/ChannelOverrides.cs ---
+// Copyright (C) 2022  Kevin Jilissen
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+namespace Jellyfin.Xtream.Configuration;
+
+/// <summary>
+/// Override configuration for a Live TV channel.
+/// </summary>
+public class ChannelOverrides
+{
+    /// <summary>
+    /// Gets or sets the TV channel number.
+    /// </summary>
+    public int? Number { get; set; }
+
+    /// <summary>
+    /// Gets or sets the TV channel name.
+    /// </summary>
+    public string? Name { get; set; }
+
+    /// <summary>
+    /// Gets or sets the url of the channel logo.
+    /// </summary>
+    public string? LogoUrl { get; set; }
+}
+--- END OF FILE: ./Jellyfin.Xtream/Configuration/ChannelOverrides.cs ---
+
+--- START OF FILE: ./Jellyfin.Xtream/Configuration/SerializableDictionary.cs ---
+// Copyright (C) 2022  Kevin Jilissen
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+using System.Xml;
+using System.Xml.Schema;
+using System.Xml.Serialization;
+
+namespace Jellyfin.Xtream.Configuration;
+
+/// <summary>
+/// Dictionary implementation that can be serialized to and from XML.
+/// </summary>
+/// <typeparam name="TKey">The dictionary key type.</typeparam>
+/// <typeparam name="TValue">The dictionary value type.</typeparam>
+[Serializable]
+[XmlRoot("Dictionary")]
+public sealed class SerializableDictionary<TKey, TValue> : Dictionary<TKey, TValue>, IXmlSerializable
+where TKey : notnull
+{
+    private const string ItemTag = "Item";
+
+    private const string KeyTag = "Key";
+
+    private const string ValueTag = "Value";
+
+    private static readonly XmlSerializer _keySerializer = new(typeof(TKey));
+
+    private static readonly XmlSerializer _valueSerializer = new(typeof(TValue));
+
+    /// <summary>Initializes a new instance of the
+    /// <see cref="SerializableDictionary&lt;TKey, TValue&gt;"/> class.
+    /// </summary>
+    public SerializableDictionary()
+    {
+    }
+
+    /// <inheritdoc />
+    public XmlSchema? GetSchema()
+    {
+        return null;
+    }
+
+    /// <inheritdoc />
+    public void ReadXml(XmlReader reader)
+    {
+        var wasEmpty = reader.IsEmptyElement;
+
+        reader.Read();
+        if (wasEmpty)
+        {
+            return;
+        }
+
+        try
+        {
+            while (reader.NodeType != XmlNodeType.EndElement)
+            {
+                ReadItem(reader);
+                reader.MoveToContent();
+            }
+        }
+        finally
+        {
+            reader.ReadEndElement();
+        }
+    }
+
+    /// <inheritdoc />
+    public void WriteXml(XmlWriter writer)
+    {
+        foreach (var keyValuePair in this)
+        {
+            SerializableDictionary<TKey, TValue>.WriteItem(writer, keyValuePair);
+        }
+    }
+
+    /// <summary>
+    /// Deserializes the dictionary item.
+    /// </summary>
+    /// <param name="reader">The XML representation of the object.</param>
+    private void ReadItem(XmlReader reader)
+    {
+        reader.ReadStartElement(ItemTag);
+        try
+        {
+            Add(SerializableDictionary<TKey, TValue>.ReadKey(reader), SerializableDictionary<TKey, TValue>.ReadValue(reader));
+        }
+        finally
+        {
+            reader.ReadEndElement();
+        }
+    }
+
+    /// <summary>
+    /// De-serializes the dictionary item's key.
+    /// </summary>
+    /// <param name="reader">The XML representation of the object.</param>
+    /// <returns>The dictionary item's key.</returns>
+    private static TKey ReadKey(XmlReader reader)
+    {
+        reader.ReadStartElement(KeyTag);
+        try
+        {
+            TKey deserialized = (TKey?)_keySerializer.Deserialize(reader) ?? throw new SerializationException("Key cannot be null");
+            return deserialized;
+        }
+        finally
+        {
+            reader.ReadEndElement();
+        }
+    }
+
+    /// <summary>
+    /// Deserializes the dictionary item's value.
+    /// </summary>
+    /// <param name="reader">The XML representation of the object.</param>
+    /// <returns>The dictionary item's value.</returns>
+    private static TValue ReadValue(XmlReader reader)
+    {
+        reader.ReadStartElement(ValueTag);
+        try
+        {
+            TValue deserialized = (TValue?)_valueSerializer.Deserialize(reader) ?? throw new SerializationException("Value cannot be null");
+            return deserialized;
+        }
+        finally
+        {
+            reader.ReadEndElement();
+        }
+    }
+
+    /// <summary>
+    /// Serializes the dictionary item.
+    /// </summary>
+    /// <param name="writer">The XML writer to serialize to.</param>
+    /// <param name="keyValuePair">The key/value pair.</param>
+    private static void WriteItem(XmlWriter writer, KeyValuePair<TKey, TValue> keyValuePair)
+    {
+        writer.WriteStartElement(ItemTag);
+        try
+        {
+            SerializableDictionary<TKey, TValue>.WriteKey(writer, keyValuePair.Key);
+            SerializableDictionary<TKey, TValue>.WriteValue(writer, keyValuePair.Value);
+        }
+        finally
+        {
+            writer.WriteEndElement();
+        }
+    }
+
+    /// <summary>
+    /// Serializes the dictionary item's key.
+    /// </summary>
+    /// <param name="writer">The XML writer to serialize to.</param>
+    /// <param name="key">The dictionary item's key.</param>
+    private static void WriteKey(XmlWriter writer, TKey key)
+    {
+        writer.WriteStartElement(KeyTag);
+        try
+        {
+            _keySerializer.Serialize(writer, key);
+        }
+        finally
+        {
+            writer.WriteEndElement();
+        }
+    }
+
+    /// <summary>
+    /// Serializes the dictionary item's value.
+    /// </summary>
+    /// <param name="writer">The XML writer to serialize to.</param>
+    /// <param name="value">The dictionary item's value.</param>
+    private static void WriteValue(XmlWriter writer, TValue value)
+    {
+        writer.WriteStartElement(ValueTag);
+        try
+        {
+            _valueSerializer.Serialize(writer, value);
+        }
+        finally
+        {
+            writer.WriteEndElement();
+        }
+    }
+}
+--- END OF FILE: ./Jellyfin.Xtream/Configuration/SerializableDictionary.cs ---
+
+--- START OF FILE: ./Jellyfin.Xtream/Jellyfin.Xtream.csproj ---
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <RootNamespace>Jellyfin.Xtream</RootNamespace>
+    <AssemblyVersion>0.8.0.0</AssemblyVersion>
+    <FileVersion>0.8.0.0</FileVersion>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <Nullable>enable</Nullable>
+    <AnalysisMode>AllEnabledByDefault</AnalysisMode>
+    <CodeAnalysisRuleSet>../jellyfin.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Jellyfin.Controller" Version="10.11.0" />
+    <PackageReference Include="Jellyfin.Model" Version="10.11.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="SerilogAnalyzer" Version="0.15.0" PrivateAssets="All" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" PrivateAssets="All" />
+    <PackageReference Include="SmartAnalyzers.MultithreadingAnalyzer" Version="1.1.31" PrivateAssets="All" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Remove="Configuration\Web\**" />
+    <EmbeddedResource Include="Configuration\Web\**" />
+  </ItemGroup>
+
+</Project>
+--- END OF FILE: ./Jellyfin.Xtream/Jellyfin.Xtream.csproj ---
+
+--- START OF FILE: ./Jellyfin.Xtream/Service/WrappedBufferStream.cs ---
+// Copyright (C) 2022  Kevin Jilissen
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System;
+using System.IO;
+
+namespace Jellyfin.Xtream.Service;
+
+/// <summary>
+/// Stream which writes to a self-overwriting internal buffer.
+/// </summary>
+/// <param name="bufferSize">Size in bytes of the internal buffer.</param>
+public class WrappedBufferStream(int bufferSize) : Stream
+{
+    /// <summary>
+    /// Gets the maximal size in bytes of read/write chunks.
+    /// </summary>
+    public int BufferSize { get => Buffer.Length; }
+
+#pragma warning disable CA1819
+    /// <summary>
+    /// Gets the internal buffer.
+    /// </summary>
+    public byte[] Buffer { get; } = new byte[bufferSize];
+#pragma warning restore CA1819
+
+    /// <summary>
+    /// Gets the number of bytes that have been written to this stream.
+    /// </summary>
+    public long TotalBytesWritten { get; private set; }
+
+    /// <inheritdoc />
+    public override long Position
+    {
+        get => TotalBytesWritten % BufferSize; set { }
+    }
+
+    /// <inheritdoc />
+    public override bool CanRead => false;
+
+    /// <inheritdoc />
+    public override bool CanWrite => true;
+
+    /// <inheritdoc />
+    public override bool CanSeek => false;
+
+    /// <inheritdoc />
+    public override long Length => throw new NotSupportedException();
+
+    /// <inheritdoc />
+    public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+    /// <inheritdoc />
+    public override void Write(byte[] buffer, int offset, int count)
+    {
+        long written = 0;
+
+        // Copy inside a loop to simplify wrapping logic.
+        while (written < count)
+        {
+            // The amount of bytes that we can directly write from the current position without wrapping.
+            long writable = Math.Min(count - written, BufferSize - Position);
+
+            // Copy the data.
+            Array.Copy(buffer, offset + written, Buffer, Position, writable);
+            written += writable;
+            TotalBytesWritten += writable;
+        }
+    }
+
+    /// <inheritdoc />
+    public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+    /// <inheritdoc />
+    public override void SetLength(long value) => throw new NotSupportedException();
+
+    /// <inheritdoc />
+    public override void Flush()
+    {
+        // Do nothing
+    }
+}
+--- END OF FILE: ./Jellyfin.Xtream/Service/WrappedBufferStream.cs ---
+
+--- START OF FILE: ./Jellyfin.Xtream/Service/StreamService.cs ---
+// Copyright (C) 2022  Kevin Jilissen
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Xtream.Client;
+using Jellyfin.Xtream.Client.Models;
+using Jellyfin.Xtream.Configuration;
+using MediaBrowser.Controller.Channels;
+using MediaBrowser.Model.Dto;
+using MediaBrowser.Model.Entities;
+using MediaBrowser.Model.MediaInfo;
+
+namespace Jellyfin.Xtream.Service;
+
+/// <summary>
+/// A service for dealing with stream information.
+/// </summary>
+/// <param name="xtreamClient">Instance of the <see cref="IXtreamClient"/> interface.</param>
+public partial class StreamService(IXtreamClient xtreamClient)
+{
+    /// <summary>
+    /// The id prefix for VOD category channel items.
+    /// </summary>
+    public const int VodCategoryPrefix = 0x5d774c35;
+
+    /// <summary>
+    /// The id prefix for stream channel items.
+    /// </summary>
+    public const int StreamPrefix = 0x5d774c36;
+
+    /// <summary>
+    /// The id prefix for series category channel items.
+    /// </summary>
+    public const int SeriesCategoryPrefix = 0x5d774c37;
+
+    /// <summary>
+    /// The id prefix for series category channel items.
+    /// </summary>
+    public const int SeriesPrefix = 0x5d774c38;
+
+    /// <summary>
+    /// The id prefix for season channel items.
+    /// </summary>
+    public const int SeasonPrefix = 0x5d774c39;
+
+    /// <summary>
+    /// The id prefix for season channel items.
+    /// </summary>
+    public const int EpisodePrefix = 0x5d774c3a;
+
+    /// <summary>
+    /// The id prefix for catchup channel items.
+    /// </summary>
+    public const int CatchupPrefix = 0x5d774c3b;
+
+    /// <summary>
+    /// The id prefix for catchup stream items.
+    /// </summary>
+    public const int CatchupStreamPrefix = 0x5d774c3c;
+
+    /// <summary>
+    /// The id prefix for media source items.
+    /// </summary>
+    public const int MediaSourcePrefix = 0x5d774c3d;
+
+    /// <summary>
+    /// The id prefix for Live TV items.
+    /// </summary>
+    public const int LiveTvPrefix = 0x5d774c3e;
+
+    /// <summary>
+    /// The id prefix for TV EPG items.
+    /// </summary>
+    public const int EpgPrefix = 0x5d774c3f;
+
+    private static readonly Regex _tagRegex = TagRegex();
+
+    /// <summary>
+    /// Parses tags in the name of a stream entry.
+    /// The name commonly contains tags of the forms:
+    /// <list>
+    /// <item>[TAG]</item>
+    /// <item>|TAG|</item>
+    /// </list>
+    /// These tags are parsed and returned as separate strings.
+    /// The returned title is cleaned from tags and trimmed.
+    /// </summary>
+    /// <param name="name">The name which should be parsed.</param>
+    /// <returns>A <see cref="ParsedName"/> struct containing the cleaned title and parsed tags.</returns>
+    public static ParsedName ParseName(string name)
+    {
+        List<string> tags = [];
+        string title = _tagRegex.Replace(
+            name,
+            (match) =>
+            {
+                for (int i = 1; i < match.Groups.Count; ++i)
+                {
+                    Group g = match.Groups[i];
+                    if (g.Success)
+                    {
+                        tags.Add(g.Value);
+                    }
+                }
+
+                return string.Empty;
+            });
+
+        // Tag prefixes separated by the a character in the unicode Block Elements range
+        int stripLength = 0;
+        for (int i = 0; i < title.Length; i++)
+        {
+            char c = title[i];
+            if (c >= '\u2580' && c <= '\u259F')
+            {
+                tags.Add(title[stripLength..i].Trim());
+                stripLength = i + 1;
+            }
+        }
+
+        return new ParsedName
+        {
+            Title = title[stripLength..].Trim(),
+            Tags = [.. tags],
+        };
+    }
+
+    private bool IsConfigured(SerializableDictionary<int, HashSet<int>> config, int category, int id)
+    {
+        return config.TryGetValue(category, out var values) && (values.Count == 0 || values.Contains(id));
+    }
+
+    /// <summary>
+    /// Gets an async iterator for the configured channels.
+    /// </summary>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>IAsyncEnumerable{StreamInfo}.</returns>
+    public async Task<IEnumerable<StreamInfo>> GetLiveStreams(CancellationToken cancellationToken)
+    {
+        PluginConfiguration config = Plugin.Instance.Configuration;
+
+        IEnumerable<StreamInfo> streams = await xtreamClient.GetLiveStreamsAsync(Plugin.Instance.Creds, cancellationToken).ConfigureAwait(false);
+        return streams.Where((StreamInfo channel) => channel.CategoryId.HasValue && IsConfigured(config.LiveTv, channel.CategoryId.Value, channel.StreamId));
+    }
+
+    /// <summary>
+    /// Gets an async iterator for the configured channels after applying the configured overrides.
+    /// </summary>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>IAsyncEnumerable{StreamInfo}.</returns>
+    public async Task<IEnumerable<StreamInfo>> GetLiveStreamsWithOverrides(CancellationToken cancellationToken)
+    {
+        PluginConfiguration config = Plugin.Instance.Configuration;
+        IEnumerable<StreamInfo> streams = await GetLiveStreams(cancellationToken).ConfigureAwait(false);
+        return streams.Select((StreamInfo stream) =>
+        {
+            if (config.LiveTvOverrides.TryGetValue(stream.StreamId, out ChannelOverrides? overrides))
+            {
+                stream.Num = overrides.Number ?? stream.Num;
+                stream.Name = overrides.Name ?? stream.Name;
+                stream.StreamIcon = overrides.LogoUrl ?? stream.StreamIcon;
+            }
+
+            return stream;
+        });
+    }
+
+    /// <summary>
+    /// Gets an channel item info for the category.
+    /// </summary>
+    /// <param name="prefix">The channel category prefix.</param>
+    /// <param name="category">The Xtream category.</param>
+    /// <returns>A channel item representing the category.</returns>
+    public static ChannelItemInfo CreateChannelItemInfo(int prefix, Category category)
+    {
+        ParsedName parsedName = ParseName(category.CategoryName);
+        return new ChannelItemInfo()
+        {
+            Id = ToGuid(prefix, category.CategoryId, 0, 0).ToString(),
+            Name = category.CategoryName,
+            Tags = new List<string>(parsedName.Tags),
+            Type = ChannelItemType.Folder,
+        };
+    }
+
+    /// <summary>
+    /// Gets an iterator for the configured VOD categories.
+    /// </summary>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>IAsyncEnumerable{StreamInfo}.</returns>
+    public async Task<IEnumerable<Category>> GetVodCategories(CancellationToken cancellationToken)
+    {
+        List<Category> categories = await xtreamClient.GetVodCategoryAsync(Plugin.Instance.Creds, cancellationToken).ConfigureAwait(false);
+        return categories.Where((Category category) => Plugin.Instance.Configuration.Vod.ContainsKey(category.CategoryId));
+    }
+
+    /// <summary>
+    /// Gets an iterator for the configured VOD streams.
+    /// </summary>
+    /// <param name="categoryId">The Xtream id of the category.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>IAsyncEnumerable{StreamInfo}.</returns>
+    public async Task<IEnumerable<StreamInfo>> GetVodStreams(int categoryId, CancellationToken cancellationToken)
+    {
+        if (!Plugin.Instance.Configuration.Vod.ContainsKey(categoryId))
+        {
+            return new List<StreamInfo>();
+        }
+
+        List<StreamInfo> streams = await xtreamClient.GetVodStreamsByCategoryAsync(Plugin.Instance.Creds, categoryId, cancellationToken).ConfigureAwait(false);
+        return streams.Where((StreamInfo stream) => IsConfigured(Plugin.Instance.Configuration.Vod, categoryId, stream.StreamId));
+    }
+
+    /// <summary>
+    /// Gets an iterator for the configured Series categories.
+    /// </summary>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>IAsyncEnumerable{StreamInfo}.</returns>
+    public async Task<IEnumerable<Category>> GetSeriesCategories(CancellationToken cancellationToken)
+    {
+        List<Category> categories = await xtreamClient.GetSeriesCategoryAsync(Plugin.Instance.Creds, cancellationToken).ConfigureAwait(false);
+        return categories.Where((Category category) => Plugin.Instance.Configuration.Series.ContainsKey(category.CategoryId));
+    }
+
+    /// <summary>
+    /// Gets an iterator for the configured Series.
+    /// </summary>
+    /// <param name="categoryId">The Xtream id of the category.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>IAsyncEnumerable{StreamInfo}.</returns>
+    public async Task<IEnumerable<Series>> GetSeries(int categoryId, CancellationToken cancellationToken)
+    {
+        if (!Plugin.Instance.Configuration.Series.ContainsKey(categoryId))
+        {
+            return new List<Series>();
+        }
+
+        List<Series> series = await xtreamClient.GetSeriesByCategoryAsync(Plugin.Instance.Creds, categoryId, cancellationToken).ConfigureAwait(false);
+        return series.Where((Series series) => IsConfigured(Plugin.Instance.Configuration.Series, series.CategoryId, series.SeriesId));
+    }
+
+    /// <summary>
+    /// Gets an iterator for the configured seasons in the Series.
+    /// </summary>
+    /// <param name="seriesId">The Xtream id of the Series.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>IAsyncEnumerable{StreamInfo}.</returns>
+    public async Task<IEnumerable<Tuple<SeriesStreamInfo, int>>> GetSeasons(int seriesId, CancellationToken cancellationToken)
+    {
+        SeriesStreamInfo series = await xtreamClient.GetSeriesStreamsBySeriesAsync(Plugin.Instance.Creds, seriesId, cancellationToken).ConfigureAwait(false);
+        int categoryId = series.Info.CategoryId;
+        if (!IsConfigured(Plugin.Instance.Configuration.Series, categoryId, seriesId))
+        {
+            return new List<Tuple<SeriesStreamInfo, int>>();
+        }
+
+        return series.Episodes.Keys.Select((int seasonId) => new Tuple<SeriesStreamInfo, int>(series, seasonId));
+    }
+
+    /// <summary>
+    /// Gets an iterator for the configured seasons in the Series.
+    /// </summary>
+    /// <param name="seriesId">The Xtream id of the Series.</param>
+    /// <param name="seasonId">The Xtream id of the Season.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>IAsyncEnumerable{StreamInfo}.</returns>
+    public async Task<IEnumerable<Tuple<SeriesStreamInfo, Season?, Episode>>> GetEpisodes(int seriesId, int seasonId, CancellationToken cancellationToken)
+    {
+        SeriesStreamInfo series = await xtreamClient.GetSeriesStreamsBySeriesAsync(Plugin.Instance.Creds, seriesId, cancellationToken).ConfigureAwait(false);
+        Season? season = series.Seasons.FirstOrDefault(s => s.SeasonId == seasonId);
+        return series.Episodes[seasonId].Select((Episode episode) => new Tuple<SeriesStreamInfo, Season?, Episode>(series, season, episode));
+    }
+
+    private static void StoreBytes(byte[] dst, int offset, int i)
+    {
+        byte[] intBytes = BitConverter.GetBytes(i);
+        if (BitConverter.IsLittleEndian)
+        {
+            Array.Reverse(intBytes);
+        }
+
+        Buffer.BlockCopy(intBytes, 0, dst, offset, 4);
+    }
+
+    /// <summary>
+    /// Gets a GUID representing the four 32-bit integers.
+    /// </summary>
+    /// <param name="i0">Bytes 0-3.</param>
+    /// <param name="i1">Bytes 4-7.</param>
+    /// <param name="i2">Bytes 8-11.</param>
+    /// <param name="i3">Bytes 12-15.</param>
+    /// <returns>Guid.</returns>
+    public static Guid ToGuid(int i0, int i1, int i2, int i3)
+    {
+        byte[] guid = new byte[16];
+        StoreBytes(guid, 0, i0);
+        StoreBytes(guid, 4, i1);
+        StoreBytes(guid, 8, i2);
+        StoreBytes(guid, 12, i3);
+        return new Guid(guid);
+    }
+
+    /// <summary>
+    /// Gets the four 32-bit integers represented in the GUID.
+    /// </summary>
+    /// <param name="id">The input GUID.</param>
+    /// <param name="i0">Bytes 0-3.</param>
+    /// <param name="i1">Bytes 4-7.</param>
+    /// <param name="i2">Bytes 8-11.</param>
+    /// <param name="i3">Bytes 12-15.</param>
+    public static void FromGuid(Guid id, out int i0, out int i1, out int i2, out int i3)
+    {
+        byte[] tmp = id.ToByteArray();
+        if (BitConverter.IsLittleEndian)
+        {
+            Array.Reverse(tmp);
+            i0 = BitConverter.ToInt32(tmp, 12);
+            i1 = BitConverter.ToInt32(tmp, 8);
+            i2 = BitConverter.ToInt32(tmp, 4);
+            i3 = BitConverter.ToInt32(tmp, 0);
+        }
+        else
+        {
+            i0 = BitConverter.ToInt32(tmp, 0);
+            i1 = BitConverter.ToInt32(tmp, 4);
+            i2 = BitConverter.ToInt32(tmp, 8);
+            i3 = BitConverter.ToInt32(tmp, 12);
+        }
+    }
+
+    /// <summary>
+    /// Gets the media source information for the given Xtream stream.
+    /// </summary>
+    /// <param name="type">The stream media type.</param>
+    /// <param name="id">The unique identifier of the stream.</param>
+    /// <param name="extension">The container extension of the stream.</param>
+    /// <param name="restream">Boolean indicating whether or not restreaming is used.</param>
+    /// <param name="start">The datetime representing the start time of catcup TV.</param>
+    /// <param name="durationMinutes">The duration in minutes of the catcup TV stream.</param>
+    /// <param name="videoInfo">The Xtream video info if known.</param>
+    /// <param name="audioInfo">The Xtream audio info if known.</param>
+    /// <returns>The media source info as <see cref="MediaSourceInfo"/> class.</returns>
+    public MediaSourceInfo GetMediaSourceInfo(
+        StreamType type,
+        int id,
+        string? extension = null,
+        bool restream = false,
+        DateTime? start = null,
+        int durationMinutes = 0,
+        VideoInfo? videoInfo = null,
+        AudioInfo? audioInfo = null)
+    {
+        string prefix = string.Empty;
+        switch (type)
+        {
+            case StreamType.Series:
+                prefix = "/series";
+                break;
+            case StreamType.Vod:
+                prefix = "/movie";
+                break;
+        }
+
+        PluginConfiguration config = Plugin.Instance.Configuration;
+        string uri = $"{config.BaseUrl}{prefix}/{config.Username}/{config.Password}/{id}";
+        if (!string.IsNullOrEmpty(extension))
+        {
+            uri += $".{extension}";
+        }
+
+        if (type == StreamType.CatchUp)
+        {
+            string? startString = start?.ToString("yyyy'-'MM'-'dd':'HH'-'mm", CultureInfo.InvariantCulture);
+            uri = $"{config.BaseUrl}/streaming/timeshift.php?username={config.Username}&password={config.Password}&stream={id}&start={startString}&duration={durationMinutes}";
+        }
+
+        bool isLive = type == StreamType.Live;
+        return new MediaSourceInfo()
+        {
+            Container = extension,
+            EncoderProtocol = MediaProtocol.Http,
+            Id = ToGuid(MediaSourcePrefix, (int)type, id, 0).ToString(),
+            IsInfiniteStream = isLive,
+            IsRemote = true,
+            MediaStreams =
+            [
+                new()
+                {
+                    AspectRatio = videoInfo?.AspectRatio,
+                    BitDepth = videoInfo?.BitsPerRawSample,
+                    Codec = videoInfo?.CodecName,
+                    ColorPrimaries = videoInfo?.ColorPrimaries,
+                    ColorRange = videoInfo?.ColorRange,
+                    ColorSpace = videoInfo?.ColorSpace,
+                    ColorTransfer = videoInfo?.ColorTransfer,
+                    Height = videoInfo?.Height,
+                    Index = videoInfo?.Index ?? -1,
+                    IsAVC = videoInfo?.IsAVC,
+                    IsInterlaced = true,
+                    Level = videoInfo?.Level,
+                    PixelFormat = videoInfo?.PixelFormat,
+                    Profile = videoInfo?.Profile,
+                    Type = MediaStreamType.Video,
+                    Width = videoInfo?.Width,
+                },
+                new()
+                {
+                    BitRate = audioInfo?.Bitrate,
+                    ChannelLayout = audioInfo?.ChannelLayout,
+                    Channels = audioInfo?.Channels,
+                    Codec = audioInfo?.CodecName,
+                    Index = audioInfo?.Index ?? -1,
+                    Profile = audioInfo?.Profile,
+                    SampleRate = audioInfo?.SampleRate,
+                    Type = MediaStreamType.Audio,
+                }
+            ],
+            Name = "default",
+            Path = uri,
+            Protocol = MediaProtocol.Http,
+            RequiresClosing = restream,
+            RequiresOpening = restream,
+            SupportsDirectPlay = true,
+            SupportsDirectStream = true,
+            SupportsProbing = true,
+        };
+    }
+
+    [GeneratedRegex(@"\[([^\]]+)\]|\|([^\|]+)\|")]
+    private static partial Regex TagRegex();
+}
+--- END OF FILE: ./Jellyfin.Xtream/Service/StreamService.cs ---
+
+--- START OF FILE: ./Jellyfin.Xtream/Service/StreamType.cs ---
+// Copyright (C) 2022  Kevin Jilissen
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+namespace Jellyfin.Xtream.Service;
+
+/// <summary>
+/// An enum describing the Xtream stream types.
+/// </summary>
+public enum StreamType : int
+{
+    /// <summary>
+    /// Live IPTV.
+    /// </summary>
+    Live = 0,
+
+    /// <summary>
+    /// Catch up IPTV.
+    /// </summary>
+    CatchUp = 1,
+
+    /// <summary>
+    /// On-demand series grouped in seasons and episodes.
+    /// </summary>
+    Series = 2,
+
+    /// <summary>
+    /// Video on-demand.
+    /// </summary>
+    Vod = 3,
+}
+--- END OF FILE: ./Jellyfin.Xtream/Service/StreamType.cs ---
+
+--- START OF FILE: ./Jellyfin.Xtream/Service/Restream.cs ---
+// Copyright (C) 2022  Kevin Jilissen
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using MediaBrowser.Common.Net;
+using MediaBrowser.Controller;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Model.Dto;
+using MediaBrowser.Model.MediaInfo;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Xtream.Service;
+
+/// <summary>
+/// A live stream implementation that can be restreamed.
+/// </summary>
+public class Restream : ILiveStream, IDirectStreamProvider, IDisposable
+{
+    /// <summary>
+    /// The global constant for the restream tuner host.
+    /// </summary>
+    public const string TunerHost = "Xtream-Restream";
+
+    private static readonly HttpStatusCode[] _redirects = [
+        HttpStatusCode.Moved,
+        HttpStatusCode.MovedPermanently,
+        HttpStatusCode.PermanentRedirect,
+        HttpStatusCode.Redirect,
+    ];
+
+    private readonly WrappedBufferStream _buffer;
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly ILogger _logger;
+    private readonly CancellationTokenSource _tokenSource;
+    private readonly string _url;
+
+    private Task? _copyTask;
+    private Stream? _inputStream;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Restream"/> class.
+    /// </summary>
+    /// <param name="appHost">Instance of the <see cref="IServerApplicationHost"/> interface.</param>
+    /// <param name="httpClientFactory">Instance of the <see cref="IHttpClientFactory"/> interface.</param>
+    /// <param name="logger">Instance of the <see cref="ILogger"/> interface.</param>
+    /// <param name="mediaSource">The media which must be restreamed.</param>
+    public Restream(IServerApplicationHost appHost, IHttpClientFactory httpClientFactory, ILogger logger, MediaSourceInfo mediaSource)
+    {
+        _httpClientFactory = httpClientFactory;
+        _logger = logger;
+        MediaSource = mediaSource;
+
+        _buffer = new WrappedBufferStream(16 * 1024 * 1024); // 16MiB
+        _tokenSource = new CancellationTokenSource();
+
+        OriginalStreamId = MediaSource.Id;
+        UniqueId = Guid.NewGuid().ToString();
+
+        _url = MediaSource.Path;
+        string path = $"/LiveTv/LiveStreamFiles/{UniqueId}/stream.ts";
+        MediaSource.Path = appHost.GetSmartApiUrl(IPAddress.Any) + path;
+        MediaSource.EncoderPath = appHost.GetApiUrlForLocalAccess() + path;
+        MediaSource.Protocol = MediaProtocol.Http;
+    }
+
+    /// <inheritdoc />
+    public int ConsumerCount { get; set; }
+
+    /// <inheritdoc />
+    public string OriginalStreamId { get; set; }
+
+    /// <inheritdoc />
+    public string TunerHostId => TunerHost;
+
+    /// <inheritdoc />
+    public bool EnableStreamSharing => true;
+
+    /// <inheritdoc />
+    public MediaSourceInfo MediaSource { get; set; }
+
+    /// <inheritdoc />
+    public string UniqueId { get; init; }
+
+    /// <inheritdoc />
+    public async Task Open(CancellationToken openCancellationToken)
+    {
+        if (_inputStream != null)
+        {
+            _logger.LogWarning("Restream for channel {ChannelId} is already open.", MediaSource.Id);
+            return;
+        }
+
+        string channelId = MediaSource.Id;
+        _logger.LogInformation("Starting restream for channel {ChannelId}.", channelId);
+
+        // Response stream is disposed manually.
+        HttpResponseMessage response = await _httpClientFactory.CreateClient(NamedClient.Default)
+            .GetAsync(_url, HttpCompletionOption.ResponseHeadersRead, openCancellationToken)
+            .ConfigureAwait(true);
+        _logger.LogDebug("Stream for channel {ChannelId} using url {Url}", channelId, _url);
+
+        // Handle a manual redirect in the case of a HTTPS to HTTP downgrade.
+        if (_redirects.Contains(response.StatusCode))
+        {
+            _logger.LogDebug("Stream for channel {ChannelId} redirected to url {Url}", channelId, response.Headers.Location);
+            response = await _httpClientFactory.CreateClient(NamedClient.Default)
+                .GetAsync(response.Headers.Location, HttpCompletionOption.ResponseHeadersRead, openCancellationToken)
+                .ConfigureAwait(true);
+        }
+
+        _inputStream = await response.Content.ReadAsStreamAsync(CancellationToken.None).ConfigureAwait(false);
+        _copyTask = _inputStream.CopyToAsync(_buffer, _tokenSource.Token)
+            .ContinueWith(
+                (Task t) =>
+                {
+                    _logger.LogInformation("Restream for channel {ChannelId} finished with state {Status}", MediaSource.Id, t.Status);
+                    _inputStream.Close();
+                    _inputStream = null;
+                },
+                CancellationToken.None,
+                TaskContinuationOptions.None,
+                TaskScheduler.Default);
+    }
+
+    /// <inheritdoc />
+    public async Task Close()
+    {
+        if (_copyTask == null)
+        {
+            throw new ArgumentNullException("copyTask");
+        }
+
+        await _tokenSource.CancelAsync().ConfigureAwait(false);
+        await _copyTask.ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public Stream GetStream()
+    {
+        if (_inputStream == null)
+        {
+            _logger.LogWarning("Restream for channel {ChannelId} was not opened.", MediaSource.Id);
+            _ = Open(CancellationToken.None);
+        }
+
+        _logger.LogInformation("Opening restream {Count} for channel {ChannelId}.", ConsumerCount, MediaSource.Id);
+        return new WrappedBufferReadStream(_buffer);
+    }
+
+    /// <summary>
+    /// Disposes the fields.
+    /// </summary>
+    /// <param name="disposing">Whether or not to dispose.</param>
+    protected virtual void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            _inputStream?.Dispose();
+            _buffer.Dispose();
+            _tokenSource.Dispose();
+        }
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        // Implement IDisposable.
+        // Do not make this method virtual.
+        // A derived class should not be able to override this method.
+        Dispose(true);
+        // This object will be cleaned up by the Dispose method.
+        // Therefore, you should call GC.SuppressFinalize to
+        // take this object off the finalization queue
+        // and prevent finalization code for this object
+        // from executing a second time.
+        GC.SuppressFinalize(this);
+    }
+}
+--- END OF FILE: ./Jellyfin.Xtream/Service/Restream.cs ---
+
+--- START OF FILE: ./Jellyfin.Xtream/Service/WrappedBufferReadStream.cs ---
+// Copyright (C) 2022  Kevin Jilissen
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System;
+using System.IO;
+using System.Threading;
+
+namespace Jellyfin.Xtream.Service;
+
+/// <summary>
+/// Stream which writes to a self-overwriting internal buffer.
+/// </summary>
+public class WrappedBufferReadStream : Stream
+{
+    private readonly WrappedBufferStream _sourceBuffer;
+
+    private readonly long _initialReadHead;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="WrappedBufferReadStream"/> class.
+    /// </summary>
+    /// <param name="sourceBuffer">The source buffer to read from.</param>
+    public WrappedBufferReadStream(WrappedBufferStream sourceBuffer)
+    {
+        _sourceBuffer = sourceBuffer;
+        _initialReadHead = Math.Max(0, sourceBuffer.TotalBytesWritten - (sourceBuffer.BufferSize / 2));
+        ReadHead = _initialReadHead;
+    }
+
+    /// <summary>
+    /// Gets the virtual position in the source buffer.
+    /// </summary>
+    public long ReadHead { get; private set; }
+
+    /// <summary>
+    /// Gets the number of bytes that have been written to this stream.
+    /// </summary>
+    public long TotalBytesRead { get => ReadHead - _initialReadHead; }
+
+    /// <inheritdoc />
+    public override long Position
+    {
+        get => ReadHead % _sourceBuffer.BufferSize; set { }
+    }
+
+    /// <inheritdoc />
+    public override bool CanRead => true;
+
+    /// <inheritdoc />
+    public override bool CanWrite => false;
+
+    /// <inheritdoc />
+    public override bool CanSeek => false;
+
+#pragma warning disable CA1065
+    /// <inheritdoc />
+    public override long Length { get => throw new NotImplementedException(); }
+#pragma warning restore CA1065
+
+    /// <inheritdoc />
+    public override int Read(byte[] buffer, int offset, int count)
+    {
+        long gap = _sourceBuffer.TotalBytesWritten - ReadHead;
+
+        // We cannot return with 0 bytes read, as that indicates the end of the stream has been reached
+        while (gap == 0)
+        {
+            Thread.Sleep(1);
+            gap = _sourceBuffer.TotalBytesWritten - ReadHead;
+        }
+
+        if (gap > _sourceBuffer.BufferSize)
+        {
+            // TODO: design good handling method.
+            // Options:
+            // - throw exception
+            // - skip to buffer.Position+1 to only read 'up-to-date' bytes.
+            throw new IOException("Reader cannot keep up");
+        }
+
+        // The number of bytes that can be copied.
+        long canCopy = Math.Min(count, gap);
+        long read = 0;
+
+        // Copy inside a loop to simplify wrapping logic.
+        while (read < canCopy)
+        {
+            // The amount of bytes that we can directly write from the current position without wrapping.
+            long readable = Math.Min(canCopy - read, _sourceBuffer.BufferSize - Position);
+
+            // Copy the data.
+            Array.Copy(_sourceBuffer.Buffer, Position, buffer, offset + read, readable);
+            read += readable;
+            ReadHead += readable;
+        }
+
+        return (int)read;
+    }
+
+    /// <inheritdoc />
+    public override void Write(byte[] buffer, int offset, int count)
+    {
+        throw new NotImplementedException();
+    }
+
+    /// <inheritdoc />
+    public override long Seek(long offset, SeekOrigin origin)
+    {
+        throw new NotImplementedException();
+    }
+
+    /// <inheritdoc />
+    public override void SetLength(long value)
+    {
+        throw new NotImplementedException();
+    }
+
+    /// <inheritdoc />
+    public override void Flush()
+    {
+        // Do nothing
+    }
+}
+--- END OF FILE: ./Jellyfin.Xtream/Service/WrappedBufferReadStream.cs ---
+
+--- START OF FILE: ./Jellyfin.Xtream/Service/TaskService.cs ---
+// Copyright (C) 2022  Kevin Jilissen
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System;
+using System.Linq;
+using MediaBrowser.Model.Tasks;
+
+namespace Jellyfin.Xtream.Service;
+
+/// <summary>
+/// A service for dealing with stream information.
+/// </summary>
+/// <param name="taskManager">Instance of the <see cref="ITaskManager"/> interface.</param>
+public class TaskService(ITaskManager taskManager)
+{
+    private static Type? FindType(string assembly, string fullName)
+    {
+        return AppDomain.CurrentDomain.GetAssemblies()
+            .Where(a =>
+                !a.IsDynamic &&
+                (a.FullName?.StartsWith($"{assembly},", StringComparison.InvariantCulture) ?? false))
+            .SelectMany(a => a.GetTypes())
+            .FirstOrDefault(t => t?.FullName == fullName);
+    }
+
+    /// <summary>
+    /// Executes a task from the given assembly and name.
+    /// </summary>
+    /// <param name="assembly">The name of the assembly to search in for the type.</param>
+    /// <param name="fullName">The full name of the task type.</param>
+    /// <exception cref="ArgumentException">If the task type is not found.</exception>
+    public void CancelIfRunningAndQueue(string assembly, string fullName)
+    {
+        Type refreshType = FindType(assembly, fullName) ?? throw new ArgumentException("Refresh task not found");
+
+        // As the type is not publicly visible, use reflection.
+        typeof(ITaskManager)
+            .GetMethod(nameof(ITaskManager.CancelIfRunningAndQueue), 1, [])?
+            .MakeGenericMethod(refreshType)?
+            .Invoke(taskManager, []);
+    }
+}
+--- END OF FILE: ./Jellyfin.Xtream/Service/TaskService.cs ---
+
+--- START OF FILE: ./Jellyfin.Xtream/Service/ParsedName.cs ---
+// Copyright (C) 2022  Kevin Jilissen
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#pragma warning disable CA1815
+#pragma warning disable CA1819
+namespace Jellyfin.Xtream.Service;
+
+/// <summary>
+/// A struct which holds information of parsed stream names.
+/// </summary>
+/// <param name="title">The parsed title.</param>
+/// <param name="tags">The parsed tags.</param>
+public readonly struct ParsedName(string title, string[] tags)
+{
+    /// <summary>
+    /// Gets the parsed title.
+    /// </summary>
+    public string Title { get; init; } = title;
+
+    /// <summary>
+    /// Gets the parsed tags.
+    /// </summary>
+    public string[] Tags { get; init; } = tags;
+}
+--- END OF FILE: ./Jellyfin.Xtream/Service/ParsedName.cs ---
+
+--- START OF FILE: ./Jellyfin.Xtream/VodChannel.cs ---
+// Copyright (C) 2022  Kevin Jilissen
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Xtream.Client.Models;
+using Jellyfin.Xtream.Providers;
+using Jellyfin.Xtream.Service;
+using MediaBrowser.Controller.Channels;
+using MediaBrowser.Controller.Providers;
+using MediaBrowser.Model.Channels;
+using MediaBrowser.Model.Dto;
+using MediaBrowser.Model.Entities;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Xtream;
+
+/// <summary>
+/// The Xtream Codes API channel.
+/// </summary>
+/// <param name="logger">Instance of the <see cref="ILogger"/> interface.</param>
+public class VodChannel(ILogger<VodChannel> logger) : IChannel, IDisableMediaSourceDisplay
+{
+    /// <inheritdoc />
+    public string? Name => "Xtream Video On-Demand";
+
+    /// <inheritdoc />
+    public string? Description => "Video On-Demand streamed from the Xtream-compatible server.";
+
+    /// <inheritdoc />
+    public string DataVersion => Plugin.Instance.DataVersion;
+
+    /// <inheritdoc />
+    public string HomePageUrl => string.Empty;
+
+    /// <inheritdoc />
+    public ChannelParentalRating ParentalRating => ChannelParentalRating.GeneralAudience;
+
+    /// <inheritdoc />
+    public InternalChannelFeatures GetChannelFeatures()
+    {
+        return new()
+        {
+            ContentTypes = [
+                ChannelMediaContentType.Movie,
+            ],
+            MediaTypes = [
+                ChannelMediaType.Video
+            ],
+        };
+    }
+
+    /// <inheritdoc />
+    public Task<DynamicImageResponse> GetChannelImage(ImageType type, CancellationToken cancellationToken)
+    {
+        switch (type)
+        {
+            default:
+                throw new ArgumentException("Unsupported image type: " + type);
+        }
+    }
+
+    /// <inheritdoc />
+    public IEnumerable<ImageType> GetSupportedChannelImages()
+    {
+        return new List<ImageType>
+        {
+            // ImageType.Primary
+        };
+    }
+
+    /// <inheritdoc />
+    public async Task<ChannelItemResult> GetChannelItems(InternalChannelItemQuery query, CancellationToken cancellationToken)
+    {
+        try
+        {
+            if (string.IsNullOrEmpty(query.FolderId))
+            {
+                return await GetCategories(cancellationToken).ConfigureAwait(false);
+            }
+
+            Guid guid = Guid.Parse(query.FolderId);
+            StreamService.FromGuid(guid, out int prefix, out int categoryId, out int _, out int _);
+            if (prefix == StreamService.VodCategoryPrefix)
+            {
+                return await GetStreams(categoryId, cancellationToken).ConfigureAwait(false);
+            }
+
+            return new ChannelItemResult()
+            {
+                TotalRecordCount = 0,
+            };
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to get channel items");
+            throw;
+        }
+    }
+
+    private Task<ChannelItemInfo> CreateChannelItemInfo(StreamInfo stream)
+    {
+        long added = long.Parse(stream.Added, CultureInfo.InvariantCulture);
+        ParsedName parsedName = StreamService.ParseName(stream.Name);
+
+        List<MediaSourceInfo> sources =
+        [
+            Plugin.Instance.StreamService.GetMediaSourceInfo(
+                StreamType.Vod,
+                stream.StreamId,
+                stream.ContainerExtension)
+        ];
+
+        ChannelItemInfo result = new ChannelItemInfo()
+        {
+            ContentType = ChannelMediaContentType.Movie,
+            DateCreated = DateTimeOffset.FromUnixTimeSeconds(added).DateTime,
+            Id = $"{StreamService.StreamPrefix}{stream.StreamId}",
+            ImageUrl = stream.StreamIcon,
+            IsLiveStream = false,
+            MediaSources = sources,
+            MediaType = ChannelMediaType.Video,
+            Name = parsedName.Title,
+            Tags = new List<string>(parsedName.Tags),
+            Type = ChannelItemType.Media,
+            ProviderIds = { { XtreamVodProvider.ProviderName, stream.StreamId.ToString(CultureInfo.InvariantCulture) } },
+        };
+
+        return Task.FromResult(result);
+    }
+
+    private async Task<ChannelItemResult> GetCategories(CancellationToken cancellationToken)
+    {
+        IEnumerable<Category> categories = await Plugin.Instance.StreamService.GetVodCategories(cancellationToken).ConfigureAwait(false);
+        List<ChannelItemInfo> items = new List<ChannelItemInfo>(
+            categories.Select((Category category) => StreamService.CreateChannelItemInfo(StreamService.VodCategoryPrefix, category)));
+        return new()
+        {
+            Items = items,
+            TotalRecordCount = items.Count
+        };
+    }
+
+    private async Task<ChannelItemResult> GetStreams(int categoryId, CancellationToken cancellationToken)
+    {
+        IEnumerable<StreamInfo> streams = await Plugin.Instance.StreamService.GetVodStreams(categoryId, cancellationToken).ConfigureAwait(false);
+        List<ChannelItemInfo> items = [.. await Task.WhenAll(streams.Select(CreateChannelItemInfo)).ConfigureAwait(false)];
+        ChannelItemResult result = new ChannelItemResult()
+        {
+            Items = items,
+            TotalRecordCount = items.Count
+        };
+        return result;
+    }
+
+    /// <inheritdoc />
+    public bool IsEnabledFor(string userId)
+    {
+        return Plugin.Instance.Configuration.IsVodVisible;
+    }
+}
+--- END OF FILE: ./Jellyfin.Xtream/VodChannel.cs ---
+
+--- START OF FILE: ./.github/dependabot.yml ---
+version: 2
+updates:
+  # Fetch and update latest `nuget` pkgs
+  - package-ecosystem: nuget
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    labels:
+      - chore
+      - dependencies
+      - nuget
+    commit-message:
+      prefix: chore
+      include: scope
+
+  # Fetch and update latest `github-actions` pkgs
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 10
+    labels:
+      - ci
+      - dependencies
+      - github_actions
+    commit-message:
+      prefix: ci
+      include: scope
+--- END OF FILE: ./.github/dependabot.yml ---
+
+--- START OF FILE: ./.github/workflows/scan-codeql.yaml ---
+name: "🔬 Run CodeQL"
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  call:
+    uses: jellyfin/jellyfin-meta-plugins/.github/workflows/scan-codeql.yaml@master
+    with:
+      dotnet-version: "9.0.*"
+      repository-name: Kevinjil/Jellyfin.Xtream
+--- END OF FILE: ./.github/workflows/scan-codeql.yaml ---
+
+--- START OF FILE: ./.github/workflows/publish.yaml ---
+name: "🚀 Publish Plugin"
+
+on:
+  release:
+    types:
+      - released
+  workflow_dispatch:
+
+jobs:
+  build:
+    uses: jellyfin/jellyfin-meta-plugins/.github/workflows/build.yaml@master
+    with:
+      dotnet-version: "9.0.*"
+      dotnet-target: "net9.0"
+  upload:
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    steps:
+      - name: Download Artifact
+        uses: actions/download-artifact@v6
+        with:
+          name: build-artifact
+      - name: Prepare GitHub Release assets
+        run: |-
+          for file in ./*; do
+            md5sum ${file#./} >> ${file%.*}.md5
+            sha256sum ${file#./} >> ${file%.*}.sha256
+          done
+          ls -l
+      - name: Upload GitHub Release assets
+        uses: shogo82148/actions-upload-release-asset@v1.9.1
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ./*
+  generate:
+    runs-on: ubuntu-latest
+    needs:
+      - upload
+    steps:
+      - name: Jellyfin plugin repo
+        uses: Kevinjil/jellyfin-plugin-repo-action@v0.4.3
+        with:
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.repository }}
+--- END OF FILE: ./.github/workflows/publish.yaml ---
+
+--- START OF FILE: ./.github/workflows/command-rebase.yaml ---
+name: '🔀 PR Rebase Command'
+
+on:
+  repository_dispatch:
+    types:
+      - rebase-command
+
+jobs:
+  call:
+    uses: jellyfin/jellyfin-meta-plugins/.github/workflows/command-rebase.yaml@master
+    with:
+      rebase-head: ${{ github.event.client_payload.pull_request.head.label }}
+      repository-full-name: ${{ github.event.client_payload.github.payload.repository.full_name }}
+      comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}
+--- END OF FILE: ./.github/workflows/command-rebase.yaml ---
+
+--- START OF FILE: ./.github/workflows/changelog.yaml ---
+name: '📝 Create/Update Release Draft & Release Bump PR'
+
+on:
+  push:
+    branches:
+      - master
+    paths-ignore:
+      - build.yaml
+  workflow_dispatch:
+  repository_dispatch:
+    types:
+      - update-prep-command
+
+jobs:
+  call:
+    uses: jellyfin/jellyfin-meta-plugins/.github/workflows/changelog.yaml@master
+    with:
+      repository-name: jellyfin/jellyfin-plugin-template
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}
+--- END OF FILE: ./.github/workflows/changelog.yaml ---
+
+--- START OF FILE: ./.github/workflows/sync-labels.yaml ---
+name: '🏷️ Sync labels'
+
+on:
+  schedule:
+    - cron: '0 0 1 * *'
+  workflow_dispatch:
+
+jobs:
+  call:
+    uses: jellyfin/jellyfin-meta-plugins/.github/workflows/sync-labels.yaml@master
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}
+--- END OF FILE: ./.github/workflows/sync-labels.yaml ---
+
+--- START OF FILE: ./.github/workflows/test.yaml ---
+name: '🧪 Test Plugin'
+
+on:
+  push:
+    branches:
+      - master
+    paths-ignore:
+      - '**/*.md'
+  pull_request:
+    branches:
+      - master
+    paths-ignore:
+      - '**/*.md'
+  workflow_dispatch:
+
+jobs:
+  call:
+    uses: jellyfin/jellyfin-meta-plugins/.github/workflows/test.yaml@master
+    with:    
+      dotnet-version: 9.0.x
+--- END OF FILE: ./.github/workflows/test.yaml ---
+
+--- START OF FILE: ./.github/workflows/build.yaml ---
+name: "🏗️ Build Plugin"
+
+on:
+  push:
+    branches:
+      - master
+    paths-ignore:
+      - "**/*.md"
+  pull_request:
+    branches:
+      - master
+    paths-ignore:
+      - "**/*.md"
+  workflow_dispatch:
+
+jobs:
+  call:
+    uses: jellyfin/jellyfin-meta-plugins/.github/workflows/build.yaml@master
+    with:
+      dotnet-version: "9.0.*"
+      dotnet-target: "net9.0"
+--- END OF FILE: ./.github/workflows/build.yaml ---
+
+--- START OF FILE: ./.github/workflows/command-dispatch.yaml ---
+# Allows for the definition of PR and Issue /commands
+name: '📟 Slash Command Dispatcher'
+
+on:
+  issue_comment:
+    types:
+      - created
+
+jobs:
+  call:
+    uses: jellyfin/jellyfin-meta-plugins/.github/workflows/command-dispatch.yaml@master
+    secrets:
+      token: .
+--- END OF FILE: ./.github/workflows/command-dispatch.yaml ---
+
+--- START OF FILE: ./.github/ISSUE_TEMPLATE/bug_report.md ---
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Software stack**
+Plugin version: xx.xx.x
+Server version: xx.xx.x
+
+Tested clients:
+- [ ] Web browser version: xx.xx.x
+- [ ] Official Android TV app version: xx.xx.x
+- [ ] Official Android app version: xx.xx.x
+- [ ] Other xxx version: xx.xx.x
+
+**Additional context**
+Add any other context about the problem here.
+--- END OF FILE: ./.github/ISSUE_TEMPLATE/bug_report.md ---
+
+--- START OF FILE: ./.github/ISSUE_TEMPLATE/feature_request.md ---
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.
+--- END OF FILE: ./.github/ISSUE_TEMPLATE/feature_request.md ---
+
+--- START OF FILE: ./LICENSE ---
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<https://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<https://www.gnu.org/licenses/why-not-lgpl.html>.
+--- END OF FILE: ./LICENSE ---
+
+--- START OF FILE: ./build.yaml ---
+---
+name: "Jellyfin Xtream"
+guid: "5d774c35-8567-46d3-a950-9bb8227a0c5d"
+version: "0.8.0.0"
+targetAbi: "10.11.0.0"
+framework: "net9.0"
+overview: "Stream content from an Xtream-compatible server."
+description: >
+  Stream Live IPTV, Video On-Demand, and Series from an Xtream-compatible server using this plugin.
+category: "Live TV"
+owner: "Kevinjil"
+artifacts:
+  - "Jellyfin.Xtream.dll"
+changelog: >
+  changelog
+--- END OF FILE: ./build.yaml ---
+
+--- START OF FILE: ./README.md ---
+# Jellyfin.Xtream
+![GitHub Downloads (all assets, all releases)](https://img.shields.io/github/downloads/Kevinjil/Jellyfin.Xtream/total)
+![GitHub Downloads (all assets, latest release)](https://img.shields.io/github/downloads/Kevinjil/Jellyfin.Xtream/latest/total)
+![GitHub commits since latest release](https://img.shields.io/github/commits-since/Kevinjil/Jellyfin.Xtream/latest)
+![Dynamic YAML Badge](https://img.shields.io/badge/dynamic/yaml?url=https%3A%2F%2Fraw.githubusercontent.com%2FKevinjil%2FJellyfin.Xtream%2Frefs%2Fheads%2Fmaster%2Fbuild.yaml&query=targetAbi&label=Jellyfin%20ABI)
+![Dynamic YAML Badge](https://img.shields.io/badge/dynamic/yaml?url=https%3A%2F%2Fraw.githubusercontent.com%2FKevinjil%2FJellyfin.Xtream%2Frefs%2Fheads%2Fmaster%2Fbuild.yaml&query=framework&label=.NET%20framework)
+
+The Jellyfin.Xtream plugin can be used to integrate the content provided by an [Xtream-compatible API](https://xtream-ui.org/api-xtreamui-xtreamcode/) in your [Jellyfin](https://jellyfin.org/) instance.
+
+## Installation
+
+The plugin can be installed using a custom plugin repository.
+To add the repository, follow these steps:
+
+1. Open your admin dashboard and navigate to `Plugins`.
+1. Select the `Repositories` tab on the top of the page.
+1. Click the `+` symbol to add a repository.
+1. Enter `Jellyfin.Xtream` as the repository name.
+1. Enter [`https://kevinjil.github.io/Jellyfin.Xtream/repository.json`](https://kevinjil.github.io/Jellyfin.Xtream/repository.json) as the repository url.
+1. Click save.
+
+To install or update the plugin, follow these steps:
+
+1. Open your admin dashboard and navigate to `Plugins`.
+1. Select the `Catalog` tab on the top of the page.
+1. Under `Live TV`, select `Jellyfin Xtream`.
+1. (Optional) Select the desired plugin version.
+1. Click `Install`.
+1. Restart your Jellyfin server to complete the installation.
+
+## Configuration
+
+The plugin requires connection information for an [Xtream-compatible API](https://xtream-ui.org/api-xtreamui-xtreamcode/).
+The following credentials should be set correctly in the `Credentials` plugin configuration tab on the admin dashboard.
+
+| Property | Description                                                                               |
+| -------- | ----------------------------------------------------------------------------------------- |
+| Base URL | The URL of the API endpoint excluding the trailing slash, including protocol (http/https) |
+| Username | The username used to authenticate to the API                                              |
+| Password | The password used to authenticate to the API                                              |
+
+### Live TV
+
+1. Open the `Live TV` configuration tab.
+1. Select the categories, or individual channels within categories, you want to be available.
+1. Click `Save` on the bottom of the page.
+1. Open the `TV Overrides` configuration tab.
+1. Modify the channel numbers, names, and icons if desired.
+1. Click `Save` on the bottom of the page.
+
+### Video On-Demand
+
+1. Open the `Video On-Demand` configuration tab.
+1. Enable `Show this channel to users`.
+1. Select the categories, or individual videos within categories, you want to be available.
+1. Click `Save` on the bottom of the page.
+
+### Series
+
+1. Open the `Series` configuration tab.
+1. Enable `Show this channel to users`.
+1. Select the categories, or individual series within categories, you want to be available.
+1. Click `Save` on the bottom of the page.
+
+### TV Catchup
+1. Open the `Live TV` configuration tab.
+1. Enable `Show the catch-up channel to users`.
+1. Click `Save` on the bottom of the page.
+
+## Known problems
+
+### Loss of confidentiality
+
+Jellyfin publishes the remote paths in the API and in the default user interface.
+As the Xtream format for remote paths includes the username and password, anyone that can access the library will have access to your credentials.
+Use this plugin with caution on shared servers.
+
+## Troubleshooting
+
+Make sure you have correctly configured your [Jellyfin networking](https://jellyfin.org/docs/general/networking/):
+
+1. Open your admin dashboard and navigate to `Networking`.
+2. Correctly configure your `Published server URIs`.
+   For example: `all=https://jellyfin.example.com`
+--- END OF FILE: ./README.md ---
+
+--- START OF FILE: ./jellyfin.ruleset ---
+<?xml version="1.0" encoding="utf-8"?>
+<RuleSet Name="Rules for Jellyfin.Server" Description="Code analysis rules for Jellyfin.Server.csproj" ToolsVersion="14.0">
+    <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
+        <!-- disable warning SA1009: Closing parenthesis should be followed by a space. -->
+        <Rule Id="SA1009" Action="None" />
+        <!-- disable warning SA1011: Closing square bracket should be followed by a space. -->
+        <Rule Id="SA1011" Action="None" />
+        <!-- disable warning SA1101: Prefix local calls with 'this.' -->
+        <Rule Id="SA1101" Action="None" />
+        <!-- disable warning SA1108: Block statements should not contain embedded comments -->
+        <Rule Id="SA1108" Action="None" />
+        <!-- disable warning SA1118: Parameter must not span multiple lines. -->
+        <Rule Id="SA1118" Action="None" />
+        <!-- disable warning SA1128:: Put constructor initializers on their own line -->
+        <Rule Id="SA1128" Action="None" />
+        <!-- disable warning SA1130: Use lambda syntax -->
+        <Rule Id="SA1130" Action="None" />
+        <!-- disable warning SA1200: 'using' directive must appear within a namespace declaration -->
+        <Rule Id="SA1200" Action="None" />
+        <!-- disable warning SA1202: 'public' members must come before 'private' members -->
+        <Rule Id="SA1202" Action="None" />
+        <!-- disable warning SA1204: Static members must appear before non-static members -->
+        <Rule Id="SA1204" Action="None" />
+        <!-- disable warning SA1309: Fields must not begin with an underscore -->
+        <Rule Id="SA1309" Action="None" />
+        <!-- disable warning SA1413: Use trailing comma in multi-line initializers -->
+        <Rule Id="SA1413" Action="None" />
+        <!-- disable warning SA1512: Single-line comments must not be followed by blank line -->
+        <Rule Id="SA1512" Action="None" />
+        <!-- disable warning SA1515: Single-line comment should be preceded by blank line -->
+        <Rule Id="SA1515" Action="None" />
+        <!-- disable warning SA1600: Elements should be documented -->
+        <Rule Id="SA1600" Action="None" />
+        <!-- disable warning SA1602: Enumeration items should be documented -->
+        <Rule Id="SA1602" Action="None" />
+        <!-- disable warning SA1633: The file header is missing or not located at the top of the file -->
+        <Rule Id="SA1633" Action="None" />
+    </Rules>
+
+    <Rules AnalyzerId="Microsoft.CodeAnalysis.NetAnalyzers" RuleNamespace="Microsoft.Design">
+        <!-- error on CA1305: Specify IFormatProvider -->
+        <Rule Id="CA1305" Action="Error" />
+        <!-- error on CA1725: Parameter names should match base declaration -->
+        <Rule Id="CA1725" Action="Error" />
+        <!-- error on CA1725: Call async methods when in an async method -->
+        <Rule Id="CA1727" Action="Error" />
+        <!-- error on CA1843: Do not use 'WaitAll' with a single task -->
+        <Rule Id="CA1843" Action="Error" />
+        <!-- error on CA2016: Forward the CancellationToken parameter to methods that take one
+            or pass in 'CancellationToken.None' explicitly to indicate intentionally not propagating the token -->
+        <Rule Id="CA2016" Action="Error" />
+        <!-- error on CA2254: Template should be a static expression -->
+        <Rule Id="CA2254" Action="Error" />
+
+        <!-- disable warning CA1014: Mark assemblies with CLSCompliantAttribute -->
+        <Rule Id="CA1014" Action="Info" />
+        <!-- disable warning CA1024: Use properties where appropriate -->
+        <Rule Id="CA1024" Action="Info" />
+        <!-- disable warning CA1031: Do not catch general exception types -->
+        <Rule Id="CA1031" Action="Info" />
+        <!-- disable warning CA1032: Implement standard exception constructors -->
+        <Rule Id="CA1032" Action="Info" />
+        <!-- disable warning CA1040: Avoid empty interfaces -->
+        <Rule Id="CA1040" Action="Info" />
+        <!-- disable warning CA1062: Validate arguments of public methods -->
+        <Rule Id="CA1062" Action="None" />
+        <!-- TODO: enable when false positives are fixed -->
+        <!-- disable warning CA1508: Avoid dead conditional code -->
+        <Rule Id="CA1508" Action="Info" />
+        <!-- disable warning CA1716: Identifiers should not match keywords -->
+        <Rule Id="CA1716" Action="Info" />
+        <!-- disable warning CA1720: Identifiers should not contain type names -->
+        <Rule Id="CA1720" Action="Info" />
+        <!-- disable warning CA1724: Type names should not match namespaces -->
+        <Rule Id="CA1724" Action="Info" />
+        <!-- disable warning CA1805: Do not initialize unnecessarily -->
+        <Rule Id="CA1805" Action="Info" />
+        <!-- disable warning CA1812: internal class that is apparently never instantiated.
+            If so, remove the code from the assembly.
+            If this class is intended to contain only static members, make it static -->
+        <Rule Id="CA1812" Action="Info" />
+        <!-- disable warning CA1822: Member does not access instance data and can be marked as static -->
+        <Rule Id="CA1822" Action="Info" />
+        <!-- disable warning CA2000: Dispose objects before losing scope -->
+        <Rule Id="CA2000" Action="Info" />
+        <!-- disable warning CA2253: Named placeholders should not be numeric values -->
+        <Rule Id="CA2253" Action="Info" />
+        <!-- disable warning CA5394: Do not use insecure randomness -->
+        <Rule Id="CA5394" Action="Info" />
+
+        <!-- disable warning CA1054: Change the type of parameter url from string to System.Uri -->
+        <Rule Id="CA1054" Action="None" />
+        <!-- disable warning CA1055: URI return values should not be strings -->
+        <Rule Id="CA1055" Action="None" />
+        <!-- disable warning CA1056: URI properties should not be strings -->
+        <Rule Id="CA1056" Action="None" />
+        <!-- disable warning CA1303: Do not pass literals as localized parameters -->
+        <Rule Id="CA1303" Action="None" />
+        <!-- disable warning CA1308: Normalize strings to uppercase -->
+        <Rule Id="CA1308" Action="None" />
+        <!-- disable warning CA1848: Use the LoggerMessage delegates -->
+        <Rule Id="CA1848" Action="None" />
+        <!-- disable warning CA2101: Specify marshaling for P/Invoke string arguments -->
+        <Rule Id="CA2101" Action="None" />
+        <!-- disable warning CA2234: Pass System.Uri objects instead of strings -->
+        <Rule Id="CA2234" Action="None" />
+    </Rules>
+</RuleSet>
+--- END OF FILE: ./jellyfin.ruleset ---
+
+--- START OF FILE: ./Jellyfin.Xtream.sln ---
+Microsoft Visual Studio Solution File, Format Version 12.00
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Jellyfin.Xtream", "Jellyfin.Xtream\Jellyfin.Xtream.csproj", "{B5EB3EDF-6FB3-4FF2-879A-22687F90EA87}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{B5EB3EDF-6FB3-4FF2-879A-22687F90EA87}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B5EB3EDF-6FB3-4FF2-879A-22687F90EA87}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B5EB3EDF-6FB3-4FF2-879A-22687F90EA87}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B5EB3EDF-6FB3-4FF2-879A-22687F90EA87}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal
+--- END OF FILE: ./Jellyfin.Xtream.sln ---
+
+--- START OF FILE: ./.editorconfig ---
+# With more recent updates Visual Studio 2017 supports EditorConfig files out of the box
+# Visual Studio Code needs an extension: https://github.com/editorconfig/editorconfig-vscode
+# For emacs, vim, np++ and other editors, see here: https://github.com/editorconfig
+###############################
+# Core EditorConfig Options   #
+###############################
+root = true
+# All files
+[*]
+indent_style = space
+indent_size = 4
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+end_of_line = lf
+max_line_length = off
+
+# YAML indentation
+[*.{yml,yaml}]
+indent_size = 2
+
+# XML indentation
+[*.{csproj,xml}]
+indent_size = 2
+
+###############################
+# .NET Coding Conventions     #
+###############################
+[*.{cs,vb}]
+# Organize usings
+dotnet_sort_system_directives_first = true
+# this. preferences
+dotnet_style_qualification_for_field = false:silent
+dotnet_style_qualification_for_property = false:silent
+dotnet_style_qualification_for_method = false:silent
+dotnet_style_qualification_for_event = false:silent
+# Language keywords vs BCL types preferences
+dotnet_style_predefined_type_for_locals_parameters_members = true:silent
+dotnet_style_predefined_type_for_member_access = true:silent
+# Parentheses preferences
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:silent
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:silent
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:silent
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary:silent
+# Modifier preferences
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:silent
+dotnet_style_readonly_field = true:suggestion
+# Expression-level preferences
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_collection_initializer = true:suggestion
+dotnet_style_explicit_tuple_names = true:suggestion
+dotnet_style_null_propagation = true:suggestion
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:silent
+dotnet_style_prefer_inferred_tuple_names = true:suggestion
+dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
+dotnet_style_prefer_auto_properties = true:silent
+dotnet_style_prefer_conditional_expression_over_assignment = true:silent
+dotnet_style_prefer_conditional_expression_over_return = true:silent
+
+###############################
+# Naming Conventions          #
+###############################
+# Style Definitions (From Roslyn)
+
+# Non-private static fields are PascalCase
+dotnet_naming_rule.non_private_static_fields_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.non_private_static_fields_should_be_pascal_case.symbols = non_private_static_fields
+dotnet_naming_rule.non_private_static_fields_should_be_pascal_case.style = non_private_static_field_style
+
+dotnet_naming_symbols.non_private_static_fields.applicable_kinds = field
+dotnet_naming_symbols.non_private_static_fields.applicable_accessibilities = public, protected, internal, protected_internal, private_protected
+dotnet_naming_symbols.non_private_static_fields.required_modifiers = static
+
+dotnet_naming_style.non_private_static_field_style.capitalization = pascal_case
+
+# Constants are PascalCase
+dotnet_naming_rule.constants_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.constants_should_be_pascal_case.symbols = constants
+dotnet_naming_rule.constants_should_be_pascal_case.style = constant_style
+
+dotnet_naming_symbols.constants.applicable_kinds = field, local
+dotnet_naming_symbols.constants.required_modifiers = const
+
+dotnet_naming_style.constant_style.capitalization = pascal_case
+
+# Static fields are camelCase and start with s_
+dotnet_naming_rule.static_fields_should_be_camel_case.severity = suggestion
+dotnet_naming_rule.static_fields_should_be_camel_case.symbols = static_fields
+dotnet_naming_rule.static_fields_should_be_camel_case.style = static_field_style
+
+dotnet_naming_symbols.static_fields.applicable_kinds = field
+dotnet_naming_symbols.static_fields.required_modifiers = static
+
+dotnet_naming_style.static_field_style.capitalization = camel_case
+dotnet_naming_style.static_field_style.required_prefix = _
+
+# Instance fields are camelCase and start with _
+dotnet_naming_rule.instance_fields_should_be_camel_case.severity = suggestion
+dotnet_naming_rule.instance_fields_should_be_camel_case.symbols = instance_fields
+dotnet_naming_rule.instance_fields_should_be_camel_case.style = instance_field_style
+
+dotnet_naming_symbols.instance_fields.applicable_kinds = field
+
+dotnet_naming_style.instance_field_style.capitalization = camel_case
+dotnet_naming_style.instance_field_style.required_prefix = _
+
+# Locals and parameters are camelCase
+dotnet_naming_rule.locals_should_be_camel_case.severity = suggestion
+dotnet_naming_rule.locals_should_be_camel_case.symbols = locals_and_parameters
+dotnet_naming_rule.locals_should_be_camel_case.style = camel_case_style
+
+dotnet_naming_symbols.locals_and_parameters.applicable_kinds = parameter, local
+
+dotnet_naming_style.camel_case_style.capitalization = camel_case
+
+# Local functions are PascalCase
+dotnet_naming_rule.local_functions_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.local_functions_should_be_pascal_case.symbols = local_functions
+dotnet_naming_rule.local_functions_should_be_pascal_case.style = local_function_style
+
+dotnet_naming_symbols.local_functions.applicable_kinds = local_function
+
+dotnet_naming_style.local_function_style.capitalization = pascal_case
+
+# By default, name items with PascalCase
+dotnet_naming_rule.members_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.members_should_be_pascal_case.symbols = all_members
+dotnet_naming_rule.members_should_be_pascal_case.style = pascal_case_style
+
+dotnet_naming_symbols.all_members.applicable_kinds = *
+
+dotnet_naming_style.pascal_case_style.capitalization = pascal_case
+
+###############################
+# C# Coding Conventions       #
+###############################
+[*.cs]
+# var preferences
+csharp_style_var_for_built_in_types = true:silent
+csharp_style_var_when_type_is_apparent = true:silent
+csharp_style_var_elsewhere = true:silent
+# Expression-bodied members
+csharp_style_expression_bodied_methods = false:silent
+csharp_style_expression_bodied_constructors = false:silent
+csharp_style_expression_bodied_operators = false:silent
+csharp_style_expression_bodied_properties = true:silent
+csharp_style_expression_bodied_indexers = true:silent
+csharp_style_expression_bodied_accessors = true:silent
+# Pattern matching preferences
+csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
+csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
+# Null-checking preferences
+csharp_style_throw_expression = true:suggestion
+csharp_style_conditional_delegate_call = true:suggestion
+# Modifier preferences
+csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:suggestion
+# Expression-level preferences
+csharp_prefer_braces = true:silent
+csharp_style_deconstructed_variable_declaration = true:suggestion
+csharp_prefer_simple_default_expression = true:suggestion
+csharp_style_pattern_local_over_anonymous_function = true:suggestion
+csharp_style_inlined_variable_declaration = true:suggestion
+
+###############################
+# C# Formatting Rules         #
+###############################
+# New line preferences
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_between_query_expression_clauses = true
+# Indentation preferences
+csharp_indent_case_contents = true
+csharp_indent_switch_labels = true
+csharp_indent_labels = flush_left
+# Space preferences
+csharp_space_after_cast = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_parentheses = false
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_around_binary_operators = before_and_after
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+# Wrapping preferences
+csharp_preserve_single_line_statements = true
+csharp_preserve_single_line_blocks = true
+--- END OF FILE: ./.editorconfig ---
+


### PR DESCRIPTION
(partially) fulfils my feature request #232  by allowing the user to define the catchup syntax. ideally it'd get the catchup cyntax from the API, but despite sniffing the API calls of tivimate and televizo, I haven't been able to identify the commonly used endpoint for that. 

The default value of the syntax is the one that your plugin currently uses, so this doesn't break anything unless that configuration is changed. 