### PR TITLE
Add support for Unicode pipe characters in tag parsing

### DIFF
--- a/Jellyfin.Xtream/Service/StreamService.cs
+++ b/Jellyfin.Xtream/Service/StreamService.cs
@@ -99,7 +99,9 @@ public partial class StreamService(IXtreamClient xtreamClient)
     /// <list>
     /// <item>[TAG]</item>
     /// <item>|TAG|</item>
+    /// <item>| TAG | (with spaces, e.g., | NL |)</item>
     /// </list>
+    /// Supports Unicode pipe variants (│, ┃, ｜) in addition to ASCII pipe.
     /// These tags are parsed and returned as separate strings.
     /// The returned title is cleaned from tags and trimmed.
     /// </summary>
@@ -444,6 +446,7 @@ public partial class StreamService(IXtreamClient xtreamClient)
         };
     }
 
-    [GeneratedRegex(@"\[([^\]]+)\]|\|([^\|]+)\|")]
+    // Matches tags in brackets [TAG] or pipe-delimited |TAG| (with optional spaces and Unicode pipe variants)
+    [GeneratedRegex(@"\[([^\]]+)\]|[|│┃｜]\s*([^|│┃｜]+?)\s*[|│┃｜]")]
     private static partial Regex TagRegex();
 }

--- a/Jellyfin.Xtream/Service/StreamService.cs
+++ b/Jellyfin.Xtream/Service/StreamService.cs
@@ -447,6 +447,7 @@ public partial class StreamService(IXtreamClient xtreamClient)
     }
 
     // Matches tags in brackets [TAG] or pipe-delimited |TAG| (with optional spaces and Unicode pipe variants)
+    // Pipe variants: | (U+007C), │ (U+2502), ┃ (U+2503), ｜ (U+FF5C)
     [GeneratedRegex(@"\[([^\]]+)\]|[|│┃｜]\s*([^|│┃｜]+?)\s*[|│┃｜]")]
     private static partial Regex TagRegex();
 }


### PR DESCRIPTION
## Summary
Enhanced title parsing to handle Unicode pipe characters commonly used by IPTV providers.

## Problem
Some IPTV providers use Unicode box-drawing characters (┃, │, ｜) instead of ASCII pipes to tag content (e.g., `┃NL┃ Breaking Bad`). These weren't being stripped from titles.

## Solution
Extended the `ParseName()` regex to recognize:
- U+2503 Box Drawings Heavy Vertical (┃)
- U+2502 Box Drawings Light Vertical (│)
- U+FF5C Fullwidth Vertical Line (｜)

## Testing
- Manual testing with real provider content containing Unicode pipe tags

## Backward Compatibility
Existing ASCII pipe handling unchanged. This is purely additive.