### PR TITLE
Add error handling to configuration UI pages

### DIFF
--- a/Jellyfin.Xtream/Configuration/Web/XtreamLive.js
+++ b/Jellyfin.Xtream/Configuration/Web/XtreamLive.js
@@ -32,6 +32,21 @@ export default function (view) {
         e.preventDefault();
         return false;
       });
+    }).catch((error) => {
+      console.error('Failed to load Live TV categories:', error);
+      Dashboard.hideLoadingMsg();
+      table.innerHTML = '';
+      const errorRow = document.createElement('tr');
+      const errorCell = document.createElement('td');
+      errorCell.colSpan = 3;
+      errorCell.style.color = '#ff6b6b';
+      errorCell.style.padding = '16px';
+      errorCell.innerHTML = 'Failed to load categories. Please check:<br>' +
+        '1. Xtream credentials are configured (Credentials tab)<br>' +
+        '2. Xtream server is accessible<br>' +
+        '3. Browser console for detailed errors';
+      errorRow.appendChild(errorCell);
+      table.appendChild(errorRow);
     });
   }));
 }

--- a/Jellyfin.Xtream/Configuration/Web/XtreamSeries.js
+++ b/Jellyfin.Xtream/Configuration/Web/XtreamSeries.js
@@ -32,6 +32,21 @@ export default function (view) {
         e.preventDefault();
         return false;
       });
+    }).catch((error) => {
+      console.error('Failed to load series categories:', error);
+      Dashboard.hideLoadingMsg();
+      table.innerHTML = '';
+      const errorRow = document.createElement('tr');
+      const errorCell = document.createElement('td');
+      errorCell.colSpan = 3;
+      errorCell.style.color = '#ff6b6b';
+      errorCell.style.padding = '16px';
+      errorCell.innerHTML = 'Failed to load categories. Please check:<br>' +
+        '1. Xtream credentials are configured (Credentials tab)<br>' +
+        '2. Xtream server is accessible<br>' +
+        '3. Browser console for detailed errors';
+      errorRow.appendChild(errorCell);
+      table.appendChild(errorRow);
     });
   }));
 }

--- a/Jellyfin.Xtream/Configuration/Web/XtreamVod.js
+++ b/Jellyfin.Xtream/Configuration/Web/XtreamVod.js
@@ -12,7 +12,7 @@ export default function (view) {
     const visible = view.querySelector("#Visible");
     getConfig.then((config) => visible.checked = config.IsVodVisible);
     const tmdbOverride = view.querySelector("#TmdbOverride");
-    getConfig.then((config) => TmdbOverride.checked = config.IsTmdbVodOverride);
+    getConfig.then((config) => tmdbOverride.checked = config.IsTmdbVodOverride);
     const table = view.querySelector('#VodContent');
     Xtream.populateCategoriesTable(
       table,
@@ -35,6 +35,21 @@ export default function (view) {
         e.preventDefault();
         return false;
       });
+    }).catch((error) => {
+      console.error('Failed to load VOD categories:', error);
+      Dashboard.hideLoadingMsg();
+      table.innerHTML = '';
+      const errorRow = document.createElement('tr');
+      const errorCell = document.createElement('td');
+      errorCell.colSpan = 3;
+      errorCell.style.color = '#ff6b6b';
+      errorCell.style.padding = '16px';
+      errorCell.innerHTML = 'Failed to load categories. Please check:<br>' +
+        '1. Xtream credentials are configured (Credentials tab)<br>' +
+        '2. Xtream server is accessible<br>' +
+        '3. Browser console for detailed errors';
+      errorRow.appendChild(errorCell);
+      table.appendChild(errorRow);
     });
   }));
 }


### PR DESCRIPTION
## Summary
Add user-friendly error handling when configuration pages fail to load categories.

## Problem
The Series, VOD, and Live TV configuration pages fail silently when:
- Xtream credentials aren't configured
- Xtream server is unreachable
- API returns an error

Users see no feedback and don't know what went wrong.

## Solution
- Add `.catch()` error handlers to `populateCategoriesTable` promises
- Display helpful error message with troubleshooting steps:
  1. Check Xtream credentials are configured (Credentials tab)
  2. Verify Xtream server is accessible
  3. Check browser console for detailed errors
- Clear table before showing error to prevent stacking messages

## Bug Fix
Also fixes a variable reference bug in `XtreamVod.js`:
- `TmdbOverride.checked` → `tmdbOverride.checked` (lowercase variable name)

## Files Changed
- `Jellyfin.Xtream/Configuration/Web/XtreamSeries.js`
- `Jellyfin.Xtream/Configuration/Web/XtreamVod.js`
- `Jellyfin.Xtream/Configuration/Web/XtreamLive.js`

## Testing
- Tested with missing credentials: error message appears
- Tested with valid credentials: categories load normally
- Tested with unreachable server: error message appears

## Backward Compatibility
No breaking changes. Purely additive error handling.